### PR TITLE
Add wrap method for wrapping a function

### DIFF
--- a/packages/javascript/src/__tests__/index.test.ts
+++ b/packages/javascript/src/__tests__/index.test.ts
@@ -23,4 +23,50 @@ describe("Appsignal", () => {
       expect(promise).resolves
     })
   })
+
+  describe("wrap", () => {
+    it("returns a value if sync function doesn't throw", async () => {
+      const value = await appsignal.wrap(() => {
+        return 42
+      })
+
+      expect(value).toEqual(42)
+    })
+
+    it("returns a no value if nothing is returned and function doesn't throw", async () => {
+      const value = await appsignal.wrap(() => {
+        Math.floor(1.3)
+      })
+
+      expect(value).toEqual(undefined)
+    })
+
+    it("reports an error if sync function throws", async () => {
+      try {
+        const value = await appsignal.wrap(() => {
+          throw new Error("test error")
+        })
+      } catch (e) {
+        expect(e.message).toEqual("test error")
+      }
+    })
+
+    it("returns a value if async function doesn't throw", async () => {
+      const value = await appsignal.wrap(() => {
+        return Promise.resolve(42)
+      })
+
+      expect(value).toEqual(42)
+    })
+
+    it("reports an error if async function throws", async () => {
+      try {
+        const value = await appsignal.wrap(async () => {
+          throw new Error("test error")
+        })
+      } catch (e) {
+        expect(e.message).toEqual("test error")
+      }
+    })
+  })
 })

--- a/packages/javascript/src/__tests__/index.test.ts
+++ b/packages/javascript/src/__tests__/index.test.ts
@@ -43,7 +43,7 @@ describe("Appsignal", () => {
 
     it("reports an error if sync function throws", async () => {
       try {
-        const value = await appsignal.wrap(() => {
+        await appsignal.wrap(() => {
           throw new Error("test error")
         })
       } catch (e) {
@@ -61,12 +61,38 @@ describe("Appsignal", () => {
 
     it("reports an error if async function throws", async () => {
       try {
-        const value = await appsignal.wrap(async () => {
+        await appsignal.wrap(async () => {
           throw new Error("test error")
         })
       } catch (e) {
         expect(e.message).toEqual("test error")
       }
+    })
+
+    it("returns a value if sync function doesn't throw (promises)", () => {
+      const promise = appsignal.wrap(() => {
+        return 42
+      })
+
+      expect(promise).resolves.toEqual(42)
+    })
+
+    it("returns a no value if nothing is returned and function doesn't throw (promises)", () => {
+      const promise = appsignal.wrap(() => {
+        Math.floor(1.3)
+      })
+
+      expect(promise).resolves.toEqual(undefined)
+    })
+
+    it("reports an error if sync function throws (promises)", async () => {
+      const promise = appsignal
+        .wrap(() => {
+          throw new Error("test error")
+        })
+        .catch(e => expect(e.message).toEqual("test error"))
+
+      expect(promise).rejects
     })
   })
 })

--- a/packages/javascript/src/index.ts
+++ b/packages/javascript/src/index.ts
@@ -142,6 +142,22 @@ export default class Appsignal {
   }
 
   /**
+   * Wraps and catches errors within a given function
+   *
+   * @param   {Function}          fn             [fn description]
+   *
+   * @return  {Promise<any>}      A Promise containing the return value of the function, or a `Span` if an error was thrown.
+   */
+  public async wrap(fn: Function): Promise<any> {
+    try {
+      return Promise.resolve(fn())
+    } catch (e) {
+      await this.sendError(e)
+      return Promise.reject(e)
+    }
+  }
+
+  /**
    * Returns an object that includes useful diagnostic information.
    * Can be used to debug the installation.
    *


### PR DESCRIPTION
Adds a `wrap()` method for wrapping an anonymous function, and reporting to AppSignal if it throws. Accepts both sync and async functions.