### PR TITLE
Add hooks, plugin-path-decorator plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "dependencies": {
     "@appsignal/javascript": "file:packages/javascript",
+    "@appsignal/plugin-path-decorator": "file:packages/plugin-path-decorator",
     "@appsignal/plugin-window-events": "file:packages/plugin-window-events",
     "@appsignal/react": "file:packages/react"
   },

--- a/packages/javascript/src/utils/functional.ts
+++ b/packages/javascript/src/utils/functional.ts
@@ -1,0 +1,19 @@
+/**
+ * Composes single-argument functions from right to left. The rightmost
+ * function can take multiple arguments as it provides the signature for
+ * the resulting composite function.
+ *
+ * Adapted from https://github.com/reduxjs/redux
+ * @param   {Function[]}      funcs          The functions to compose.
+ * @returns                   {Function}     A function obtained by composing the argument functions
+ * from right to left. For example, compose(f, g, h) is identical to doing
+ * (...args) => f(g(h(...args))).
+ */
+
+export function compose<T>(...funcs: ((arg: T) => T)[]) {
+  if (funcs.length === 1) {
+    return funcs[0]
+  }
+
+  return funcs.reduce((a, b) => (...args) => a(b(...args)))
+}

--- a/packages/plugin-path-decorator/.npmignore
+++ b/packages/plugin-path-decorator/.npmignore
@@ -1,0 +1,3 @@
+*
+!/dist/**/*
+*.tsbuildinfo

--- a/packages/plugin-path-decorator/LICENSE
+++ b/packages/plugin-path-decorator/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 AppSignal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/plugin-path-decorator/jest.config.js
+++ b/packages/plugin-path-decorator/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "jsdom",
+  roots: [
+    "<rootDir>/src"
+  ],
+  transform: {
+    "^.+\\.tsx?$": "ts-jest"
+  },
+}

--- a/packages/plugin-path-decorator/package.json
+++ b/packages/plugin-path-decorator/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@appsignal/plugin-path-decorator",
+  "version": "0.0.0",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "repository": "git@github.com:appsignal/appsignal-javascript.git",
+  "author": "Adam Yeats <adam@appsignal.com>",
+  "license": "MIT",
+  "scripts": {
+    "build": "run-s build:cjs build:esm",
+    "build:esm": "tsc -p tsconfig.esm.json",
+    "build:esm:watch": "tsc -p tsconfig.esm.json -w --preserveWatchOutput",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:cjs:watch": "tsc -p tsconfig.cjs.json -w --preserveWatchOutput",
+    "build:watch": "run-p build:cjs:watch build:esm:watch",
+    "clean": "rimraf dist coverage",
+    "link:yarn": "yarn link",
+    "test": "jest",
+    "test:watch": "jest --watch"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/plugin-path-decorator/src/index.ts
+++ b/packages/plugin-path-decorator/src/index.ts
@@ -1,0 +1,10 @@
+function pathDecoratorPlugin(options?: { [key: string]: any }) {
+  return function(this: any) {
+    const decorator = (span: any) =>
+      span.setTags({ path: window.location.pathname })
+
+    this._hooks.decorators.push(decorator)
+  }
+}
+
+export const plugin = pathDecoratorPlugin

--- a/packages/plugin-path-decorator/tsconfig.cjs.json
+++ b/packages/plugin-path-decorator/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/cjs",
+    "module": "commonjs"
+  }
+}

--- a/packages/plugin-path-decorator/tsconfig.esm.json
+++ b/packages/plugin-path-decorator/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/esm",
+    "module": "es6"
+  }
+}

--- a/packages/plugin-path-decorator/tsconfig.json
+++ b/packages/plugin-path-decorator/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*"],
+  "exclude": [
+    "src/**/__tests__",
+    "src/**/__mocks__"
+  ],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "target": "es5"
+  }
+}


### PR DESCRIPTION
Closes #25 .

This adds the ability to add a _hook_, which is a function to be run on a `Span` before and after the `tags` and `namespace` from the arguments of `.send()` are applied. It also allows `Span`s to be modified at a global level, paving the way for the option to provide custom scrubbing logic.

A hook can either be a _decorator_ or an _override_.

A Span can be "decorated" with metadata after it has been created, but **before** it is sent to the API and **before** metadata provided as arguments is added. A Span can be "overridden" with metadata after it has been created, but **before** it is sent to the API and **after** metadata provided as arguments is added.

Decorators and overrides must be composable, pure functions that take a `Span` as a unary argument and a `Span` as a return value.

This also adds the `plugin-path-decorator` plugin, which adds the current `window.location.pathname` to every `Span`.