### PR TITLE
Remove action names from integrations and plugins

### DIFF
--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -1,7 +1,5 @@
 import { ErrorHandler, Injectable } from "@angular/core"
 
-const DEFAULT_ACTION = "AppsignalErrorHandler"
-
 @Injectable()
 export class AppsignalErrorHandler extends ErrorHandler {
   private _appsignal: any
@@ -14,10 +12,7 @@ export class AppsignalErrorHandler extends ErrorHandler {
   public handleError(error: any): void {
     const span = this._appsignal.createSpan()
 
-    span
-      .setAction(DEFAULT_ACTION)
-      .setError(error)
-      .setTags({ framework: "Angular" })
+    span.setError(error).setTags({ framework: "Angular" })
 
     this._appsignal.send(span)
 

--- a/packages/ember/src/index.ts
+++ b/packages/ember/src/index.ts
@@ -10,9 +10,7 @@ export function installErrorHandler(
   }
 
   Ember.onerror = function(error: Error): void {
-    const span = appsignal.createSpan((span: any) =>
-      span.setAction("Ember.onerror").setError(error)
-    )
+    const span = appsignal.createSpan((span: any) => span.setError(error))
 
     appsignal.send(span)
 
@@ -25,9 +23,7 @@ export function installErrorHandler(
 
   // fired when ember's internal promise implementation throws an unhandled exception
   Ember.RSVP.on("error", function(reason: any): void {
-    const span = appsignal.createSpan((span: any) =>
-      span.setAction("Ember.RSVP.on")
-    )
+    const span = appsignal.createSpan()
 
     if (reason instanceof Error) {
       span.setError(reason)

--- a/packages/plugin-window-events/src/__tests__/index.test.ts
+++ b/packages/plugin-window-events/src/__tests__/index.test.ts
@@ -36,7 +36,6 @@ describe("windowEventsPlugin", () => {
       ctx.onerror!(msg, "test", 1, 1, error)
 
       expect(mockAppsignal.createSpan).toHaveBeenCalled()
-      expect(setActionMock).toHaveBeenCalledWith("window.onerror")
       expect(setErrorMock).toHaveBeenCalledWith(error)
     })
 
@@ -48,7 +47,6 @@ describe("windowEventsPlugin", () => {
       ctx.onerror!(msg, "test", 1, 1)
 
       expect(mockAppsignal.createSpan).toHaveBeenCalled()
-      expect(setActionMock).toHaveBeenCalledWith("window.onerror")
 
       expect(setErrorMock).toHaveBeenCalledWith({
         name: "Error",
@@ -65,7 +63,6 @@ describe("windowEventsPlugin", () => {
       ctx.onunhandledrejection!({ reason: "test" } as PromiseRejectionEvent)
 
       expect(mockAppsignal.createSpan).toHaveBeenCalled()
-      expect(setActionMock).toHaveBeenCalledWith("window.onunhandledrejection")
 
       expect(setErrorMock).toHaveBeenCalledWith({
         name: "UnhandledPromiseRejectionError",
@@ -83,7 +80,6 @@ describe("windowEventsPlugin", () => {
       ctx.onunhandledrejection!({ reason: error } as PromiseRejectionEvent)
 
       expect(mockAppsignal.createSpan).toHaveBeenCalled()
-      expect(setActionMock).toHaveBeenCalledWith("window.onunhandledrejection")
 
       expect(setErrorMock).toHaveBeenCalledWith({
         name: "UnhandledPromiseRejectionError",

--- a/packages/plugin-window-events/src/index.ts
+++ b/packages/plugin-window-events/src/index.ts
@@ -37,8 +37,6 @@ function windowEventsPlugin(options?: { [key: string]: any }) {
           "[APPSIGNAL]: Cross-domain or eval script error detected, error ignored"
         )
       } else {
-        span.setAction("window.onerror")
-
         if (error) {
           span.setError(error)
         } else {
@@ -64,8 +62,6 @@ function windowEventsPlugin(options?: { [key: string]: any }) {
       error: PromiseRejectionEvent
     ): void {
       const span = self.createSpan()
-
-      span.setAction("window.onunhandledrejection")
 
       span.setError({
         name: "UnhandledPromiseRejectionError",

--- a/packages/preact/src/ErrorBoundary.tsx
+++ b/packages/preact/src/ErrorBoundary.tsx
@@ -1,13 +1,11 @@
 import { Component } from "preact"
 import { Props, State } from "./types/component"
 
-const DEFAULT_ACTION = "ErrorBoundary"
-
 export class ErrorBoundary extends Component<Props, State> {
   state = { error: undefined }
 
   static defaultProps = {
-    action: DEFAULT_ACTION
+    action: ""
   }
 
   public componentDidCatch(error: Error, info: any): void {
@@ -16,7 +14,7 @@ export class ErrorBoundary extends Component<Props, State> {
     const span = appsignal.createSpan()
 
     span
-      .setAction(action !== "" ? action : DEFAULT_ACTION)
+      .setAction(action !== "" ? action : undefined)
       .setError({
         name,
         message,

--- a/packages/react/src/ErrorBoundary.tsx
+++ b/packages/react/src/ErrorBoundary.tsx
@@ -1,13 +1,11 @@
 import React from "react"
 import { Props, State } from "./types/component"
 
-const DEFAULT_ACTION = "ErrorBoundary"
-
 export class ErrorBoundary extends React.Component<Props, State> {
   state = { error: undefined }
 
   static defaultProps = {
-    action: DEFAULT_ACTION
+    action: ""
   }
 
   static getDerivedStateFromError(error: Error): State {
@@ -20,7 +18,7 @@ export class ErrorBoundary extends React.Component<Props, State> {
     const span = appsignal.createSpan()
 
     span
-      .setAction(action !== "" ? action : DEFAULT_ACTION)
+      .setAction(action !== "" ? action : undefined)
       .setError({
         name,
         message,

--- a/packages/react/src/LegacyBoundary.tsx
+++ b/packages/react/src/LegacyBoundary.tsx
@@ -1,13 +1,11 @@
 import React from "react"
 import { Props, State } from "./types/component"
 
-const DEFAULT_ACTION = "LegacyBoundary"
-
 export class LegacyBoundary extends React.Component<Props, State> {
   state = { error: undefined }
 
   static defaultProps = {
-    action: DEFAULT_ACTION
+    action: ""
   }
 
   public unstable_handleError(error: Error): void {
@@ -16,7 +14,7 @@ export class LegacyBoundary extends React.Component<Props, State> {
     const span = appsignal.createSpan()
 
     span
-      .setAction(action !== "" ? action : DEFAULT_ACTION)
+      .setAction(action !== "" ? action : undefined)
       .setError({
         name,
         message,

--- a/packages/stimulus/src/index.ts
+++ b/packages/stimulus/src/index.ts
@@ -1,13 +1,9 @@
 export function installErrorHandler(appsignal: any, application: any) {
-  const DEFAULT_ACTION = "Application.handleError"
   const prevHandler = application.handleError
 
   application.handleError = function(error: Error, message: string) {
     const span = appsignal.createSpan((span: any) =>
-      span
-        .setAction(DEFAULT_ACTION)
-        .setTags({ framework: "Stimulus", message })
-        .setError(error)
+      span.setTags({ framework: "Stimulus", message }).setError(error)
     )
 
     appsignal.send(span)

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,5 +1,4 @@
 export function errorHandler(appsignal: any, Vue?: any) {
-  const DEFAULT_ACTION = "Vue.config.errorHandler"
   const { version = "unknown" } = Vue
 
   return function(error: Error, vm: any, info: string) {
@@ -7,7 +6,7 @@ export function errorHandler(appsignal: any, Vue?: any) {
     const span = appsignal.createSpan()
 
     span
-      .setAction(tag || DEFAULT_ACTION)
+      .setAction(tag || undefined)
       .setTags({ framework: "Vue", info, version })
       .setError(error)
 


### PR DESCRIPTION
Closes #39. This removes action names from all integrations and plugins, as discussed in #39.