### PR TITLE
Sanitize tags and params, more runtime type checking

### DIFF
--- a/packages/javascript/src/span.ts
+++ b/packages/javascript/src/span.ts
@@ -1,5 +1,6 @@
 import { Serializable } from "./serializable"
 import { getStacktrace } from "./utils/stacktrace"
+import { sanitizeParams } from "./utils/object"
 import { Span as AppsignalSpan } from "./types/span"
 
 export class Span extends Serializable<AppsignalSpan> {
@@ -21,11 +22,19 @@ export class Span extends Serializable<AppsignalSpan> {
   }
 
   public setAction(name: string): this {
+    if (!name || typeof name !== "string") {
+      return this
+    }
+
     this._data.action = name
     return this
   }
 
   public setNamespace(name: string): this {
+    if (!name || typeof name !== "string") {
+      return this
+    }
+
     this._data.namespace = name
     return this
   }
@@ -43,12 +52,12 @@ export class Span extends Serializable<AppsignalSpan> {
   }
 
   public setTags(tags: object): this {
-    this._data.tags = { ...this._data.tags, ...tags }
+    this._data.tags = { ...this._data.tags, ...sanitizeParams(tags) }
     return this
   }
 
   public setParams(params: object): this {
-    this._data.params = { ...this._data.params, ...params }
+    this._data.params = { ...this._data.params, ...sanitizeParams(params) }
     return this
   }
 }

--- a/packages/javascript/src/utils/object.ts
+++ b/packages/javascript/src/utils/object.ts
@@ -1,0 +1,20 @@
+/**
+ * Converts all values in a flat object to a string.
+ *
+ * Adapted from https://stackoverflow.com/questions/46982698/how-do-i-convert-all-property-values-in-an-object-to-type-string
+ *
+ * @param   {object}  obj:      A flat object structure
+ *
+ * @return  {object}            A sanitized object
+ */
+export function sanitizeParams(obj: { [key: string]: any }): object {
+  Object.keys(obj).forEach(k => {
+    if (typeof obj[k] === "object") {
+      return sanitizeParams(obj[k])
+    }
+
+    obj[k] = String(obj[k])
+  })
+
+  return obj
+}


### PR DESCRIPTION
This PR sanitizes any `tags` or `params` passed to a `Span` by converting all values to a string.  Use case would be where a user ID might reasonably be `typeof number`.