### PR TITLE
Add Appsignal.demo() method

### DIFF
--- a/packages/javascript/src/index.ts
+++ b/packages/javascript/src/index.ts
@@ -226,6 +226,20 @@ export default class Appsignal {
   }
 
   /**
+   * Sends a demonstration error to AppSignal.
+   *
+   * @return  {void}
+   */
+  public demo(): void {
+    this.sendError(
+      new Error(
+        "Hello world! This is an error used for demonstration purposes."
+      ),
+      { demo_sample: true }
+    )
+  }
+
+  /**
    * Creates a valid AppSignal `Span` from a JavaScript `Error`
    * object.
    *

--- a/packages/javascript/src/index.ts
+++ b/packages/javascript/src/index.ts
@@ -231,12 +231,23 @@ export default class Appsignal {
    * @return  {void}
    */
   public demo(): void {
-    this.sendError(
+    const span = this._createSpanFromError(
       new Error(
         "Hello world! This is an error used for demonstration purposes."
-      ),
-      { demo_sample: true }
+      )
     )
+
+    span
+      .setAction("TestAction")
+      .setParams({
+        path: "/hello",
+        method: "GET"
+      })
+      .setTags({
+        demo_sample: "true"
+      })
+
+    this.send(span)
   }
 
   /**


### PR DESCRIPTION
Per discussion on Slack, this adds a `demo()` method to the `Appsignal` class, that will send a demonstration error as part of our onboarding process.