### PR TITLE
Remove some optional properties from Span, set NullError

### DIFF
--- a/packages/javascript/src/span.ts
+++ b/packages/javascript/src/span.ts
@@ -9,15 +9,11 @@ export class Span extends Serializable<SpanData> {
     super({
       timestamp: Math.round(new Date().getTime() / 1000),
       namespace: "frontend",
-      revision: "",
       error: {
-        name: "",
-        message: "",
+        name: "NullError",
+        message: "No error has been set",
         backtrace: []
       },
-      environment: {},
-      tags: {},
-      params: {},
       ...span
     })
   }


### PR DESCRIPTION
Removes some properties that were otherwise optional from where the `Span` is initialised. Also sets the default values for `span.error` to a value, so that the user/we can see when an error has not been set using `setError()` easier.