### PR TITLE
Correctly pass the namespace from the constructor to the Span

### DIFF
--- a/packages/javascript/src/__tests__/index.test.ts
+++ b/packages/javascript/src/__tests__/index.test.ts
@@ -18,6 +18,16 @@ describe("Appsignal", () => {
     expect(appsignal.VERSION).toEqual(VERSION)
   })
 
+  it("recieves a namespace if one is passed to the constructor", () => {
+    appsignal = new Appsignal({ key: "TESTKEY", namespace: "test" })
+
+    const span = appsignal.createSpan()
+    const result = span.serialize()
+
+    expect(result).toHaveProperty("namespace")
+    expect(result.namespace).toEqual("test")
+  })
+
   describe("sendError", () => {
     it("pushes an error", () => {
       const message = "test error"

--- a/packages/javascript/src/index.ts
+++ b/packages/javascript/src/index.ts
@@ -182,11 +182,12 @@ export default class Appsignal {
    * @return  {Span}              An AppSignal `Span` object
    */
   public createSpan(fn?: Function): Span {
-    const { revision = "" } = this._options
+    const { revision = "", namespace } = this._options
 
     const span = new Span({
       environment: this._env,
-      revision
+      revision,
+      namespace
     })
 
     if (fn && typeof fn === "function") fn(span)


### PR DESCRIPTION
Fixes a bug report from Intercom yesterday. For some reason, `namespace` from the constructor options was not passed to any new instance of a `Span`, so we do that now!