### PR TITLE
Remove UA string and platform identifiers from Environment object

### DIFF
--- a/packages/javascript/src/environment.ts
+++ b/packages/javascript/src/environment.ts
@@ -5,9 +5,6 @@ export class Environment {
   public static serialize(): { [key: string]: string } {
     return {
       transport: this.transport(),
-      agent: window.navigator.userAgent,
-      platform: window.navigator.platform,
-      vendor: window.navigator.vendor,
       origin: this.origin()
     }
   }


### PR DESCRIPTION
As discussed in Slack, we have decided to no longer capture the UA string or platform identifiers, as we now gather a different data set server-side.