### PR TITLE
Remove error-stack-parser as dependency

### DIFF
--- a/packages/javascript/package.json
+++ b/packages/javascript/package.json
@@ -25,7 +25,6 @@
   },
   "dependencies": {
     "@appsignal/types": "^1.0.0-beta.1",
-    "error-stack-parser": "^2.0.2",
     "tslib": "^1.10.0"
   }
 }

--- a/packages/javascript/src/utils/stacktrace.ts
+++ b/packages/javascript/src/utils/stacktrace.ts
@@ -1,5 +1,3 @@
-import ErrorStackParser from "error-stack-parser"
-
 /**
  * Get backtrace from an `Error` object, or an error-like object
  *
@@ -8,17 +6,21 @@ import ErrorStackParser from "error-stack-parser"
  * @return  {string[]}                 A backtrace
  */
 export function getStacktrace<T extends Error>(error: Error | T): string[] {
-  if (error instanceof Error) {
-    try {
-      const frames = ErrorStackParser.parse(error)
-      return frames.map(f => f.source || "")
-    } catch (e) {
-      // probably IE9 or another browser where we can't get a stack
-      return ["No stacktrace available"]
-    }
-  } else {
-    // a plain object that resembles an error
+  if (
+    typeof (error as any).stacktrace !== "undefined" ||
+    typeof (error as any)["opera#sourceloc"] !== "undefined"
+  ) {
+    // probably opera
+    const { stacktrace = "" } = error as any
+    return stacktrace
+      .split("\n")
+      .filter((line: string | undefined) => line !== "")
+  } else if (error.stack) {
+    // an Error or a plain object that resembles an error
     const { stack = "" } = error
     return stack.split("\n").filter(line => line !== "")
+  } else {
+    // probably IE9 :(
+    return ["No stacktrace available"]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,7 +19,6 @@
   version "1.0.0-beta.11"
   dependencies:
     "@appsignal/types" "^1.0.0-beta.1"
-    error-stack-parser "^2.0.2"
     tslib "^1.10.0"
 
 "@appsignal/plugin-path-decorator@file:packages/plugin-path-decorator":
@@ -3117,13 +3116,6 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
-
-error-stack-parser@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.0.2.tgz#4ae8dbaa2bf90a8b450707b9149dcabca135520d"
-  integrity sha512-E1fPutRDdIj/hohG0UpT5mayXNCxXP9d+snxFsPU9X0XgccOumKraa3juDMwTUyi7+Bu5+mCGagjg4IYeNbOdw==
-  dependencies:
-    stackframe "^1.0.4"
 
 es-abstract@^1.4.3, es-abstract@^1.5.1:
   version "1.13.0"
@@ -7354,11 +7346,6 @@ stack-utils@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
   integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
-
-stackframe@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.0.4.tgz#357b24a992f9427cba6b545d96a14ed2cbca187b"
-  integrity sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw==
 
 staged-git-files@1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This PR removes the dependency of `error-stack-parser`, as we don't need to use almost all of the features it provides. It also introduces a bug where the processor expects sourcemaps to start from line 0, but `error-stack-parser` causes them to start from line 1. 

Instead, I have adapted some of the code from it to better handle the raw stacktrace from the `Error` object passed to a `Span`.