### PR TITLE
Add console breadcrumbs plugin

### DIFF
--- a/packages/plugin-breadcrumbs-console/.npmignore
+++ b/packages/plugin-breadcrumbs-console/.npmignore
@@ -1,0 +1,3 @@
+*
+!/dist/**/*
+*.tsbuildinfo

--- a/packages/plugin-breadcrumbs-console/LICENSE
+++ b/packages/plugin-breadcrumbs-console/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 AppSignal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/plugin-breadcrumbs-console/jest.config.js
+++ b/packages/plugin-breadcrumbs-console/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "jsdom",
+  roots: [
+    "<rootDir>/src"
+  ],
+  transform: {
+    "^.+\\.tsx?$": "ts-jest"
+  },
+}

--- a/packages/plugin-breadcrumbs-console/package.json
+++ b/packages/plugin-breadcrumbs-console/package.json
@@ -7,7 +7,7 @@
   "author": "Adam Yeats <adam@appsignal.com>",
   "license": "MIT",
   "scripts": {
-    "build": "run-s build:cjs build:esm",
+    "build": "yarn build:cjs && yarn build:esm",
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:esm:watch": "tsc -p tsconfig.esm.json -w --preserveWatchOutput",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/plugin-breadcrumbs-console/package.json
+++ b/packages/plugin-breadcrumbs-console/package.json
@@ -20,5 +20,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@appsignal/types": "^1.0.0-beta.1"
   }
 }

--- a/packages/plugin-breadcrumbs-console/package.json
+++ b/packages/plugin-breadcrumbs-console/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@appsignal/plugin-breadcrumbs-console",
+  "version": "0.0.0",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "repository": "git@github.com:appsignal/appsignal-javascript.git",
+  "author": "Adam Yeats <adam@appsignal.com>",
+  "license": "MIT",
+  "scripts": {
+    "build": "run-s build:cjs build:esm",
+    "build:esm": "tsc -p tsconfig.esm.json",
+    "build:esm:watch": "tsc -p tsconfig.esm.json -w --preserveWatchOutput",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:cjs:watch": "tsc -p tsconfig.cjs.json -w --preserveWatchOutput",
+    "build:watch": "run-p build:cjs:watch build:esm:watch",
+    "clean": "rimraf dist coverage",
+    "link:yarn": "yarn link",
+    "test": "jest --passWithNoTests",
+    "test:watch": "jest --watch"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/plugin-breadcrumbs-console/src/index.ts
+++ b/packages/plugin-breadcrumbs-console/src/index.ts
@@ -1,0 +1,45 @@
+import { Breadcrumb } from "@appsignal/types"
+
+const SUPPORTED_CONSOLE_METHODS = ["log", "debug", "info", "warn", "error"]
+
+function consoleBreadcrumbsPlugin(options?: { [key: string]: any }) {
+  const CONSOLE_LOG_METHODS = SUPPORTED_CONSOLE_METHODS.filter(
+    (method: string) =>
+      typeof console !== "undefined" &&
+      typeof (console as any)[method] === "function"
+  )
+
+  return function(this: any) {
+    const self = this
+
+    CONSOLE_LOG_METHODS.forEach((method: string) => {
+      const prevHandler = (console as any)[method]
+
+      function _console(...args: any[]) {
+        const breadcrumb: Omit<Breadcrumb, "timestamp"> = {
+          category: "Console logged a value",
+          action: `console.${method}`,
+          metadata: {}
+        }
+
+        args.forEach(
+          (arg, i) =>
+            // we're sure the `metadata` property exists
+            (breadcrumb.metadata![`argument${i}`] =
+              // attempt to get a useful value
+              // the `metadata` object should be <string, string>, so nested
+              // objects won't necessarily work here
+              typeof arg === "string" ? arg : JSON.stringify(arg))
+        )
+
+        self.addBreadcrumb(breadcrumb)
+
+        prevHandler.apply(console, args)
+      }
+
+      ;(console as any)[method] = _console
+    })
+  }
+}
+
+export const plugin = consoleBreadcrumbsPlugin

--- a/packages/plugin-breadcrumbs-console/src/index.ts
+++ b/packages/plugin-breadcrumbs-console/src/index.ts
@@ -17,7 +17,10 @@ function consoleBreadcrumbsPlugin(options?: { [key: string]: any }) {
 
       function _console(...args: any[]) {
         const breadcrumb: Omit<Breadcrumb, "timestamp"> = {
-          category: "Console logged a value",
+          category:
+            args.length > 1
+              ? "Console logged some values"
+              : "Console logged a value",
           action: `console.${method}`,
           metadata: {}
         }

--- a/packages/plugin-breadcrumbs-console/tsconfig.cjs.json
+++ b/packages/plugin-breadcrumbs-console/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/cjs",
+    "module": "commonjs"
+  }
+}

--- a/packages/plugin-breadcrumbs-console/tsconfig.esm.json
+++ b/packages/plugin-breadcrumbs-console/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/esm",
+    "module": "es6"
+  }
+}

--- a/packages/plugin-breadcrumbs-console/tsconfig.json
+++ b/packages/plugin-breadcrumbs-console/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*"],
+  "exclude": [
+    "src/**/__tests__",
+    "src/**/__mocks__"
+  ],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "target": "es5"
+  }
+}


### PR DESCRIPTION
This adds a plugin for breadcrumbs that attempts to parse anything sent to one of the appropriate `console` methods and adds it as a breadcrumb.