### PR TITLE
Add plugin for network breadcrumbs

### DIFF
--- a/packages/plugin-breadcrumbs-network/.npmignore
+++ b/packages/plugin-breadcrumbs-network/.npmignore
@@ -1,0 +1,3 @@
+*
+!/dist/**/*
+*.tsbuildinfo

--- a/packages/plugin-breadcrumbs-network/LICENSE
+++ b/packages/plugin-breadcrumbs-network/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 AppSignal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/plugin-breadcrumbs-network/jest.config.js
+++ b/packages/plugin-breadcrumbs-network/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "jsdom",
+  roots: [
+    "<rootDir>/src"
+  ],
+  transform: {
+    "^.+\\.tsx?$": "ts-jest"
+  },
+}

--- a/packages/plugin-breadcrumbs-network/package.json
+++ b/packages/plugin-breadcrumbs-network/package.json
@@ -7,7 +7,7 @@
   "author": "Adam Yeats <adam@appsignal.com>",
   "license": "MIT",
   "scripts": {
-    "build": "run-s build:cjs build:esm",
+    "build": "yarn build:cjs && yarn build:esm",
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:esm:watch": "tsc -p tsconfig.esm.json -w --preserveWatchOutput",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/plugin-breadcrumbs-network/package.json
+++ b/packages/plugin-breadcrumbs-network/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@appsignal/plugin-breadcrumbs-network",
+  "version": "0.0.0",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "repository": "git@github.com:appsignal/appsignal-javascript.git",
+  "author": "Adam Yeats <adam@appsignal.com>",
+  "license": "MIT",
+  "scripts": {
+    "build": "run-s build:cjs build:esm",
+    "build:esm": "tsc -p tsconfig.esm.json",
+    "build:esm:watch": "tsc -p tsconfig.esm.json -w --preserveWatchOutput",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:cjs:watch": "tsc -p tsconfig.cjs.json -w --preserveWatchOutput",
+    "build:watch": "run-p build:cjs:watch build:esm:watch",
+    "clean": "rimraf dist coverage",
+    "link:yarn": "yarn link",
+    "test": "jest --passWithNoTests",
+    "test:watch": "jest --watch"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/plugin-breadcrumbs-network/src/index.ts
+++ b/packages/plugin-breadcrumbs-network/src/index.ts
@@ -1,0 +1,111 @@
+/**
+ *
+ * @param options
+ */
+function networkBreadcrumbsPlugin(options?: { [key: string]: any }) {
+  const opts = {
+    xhrEnabled: true,
+    fetchEnabled: true,
+    ...options
+  }
+
+  // feature detect browser features if they are enabled
+  opts.xhrEnabled = opts.xhrEnabled ? "XMLHttpRequest" in window : false
+  opts.fetchEnabled = opts.xhrEnabled ? "fetch" in window : false
+
+  return function(this: any): void {
+    const xhrPatch = () => {
+      const appsignal = this
+      const prevOpen = XMLHttpRequest.prototype.open
+
+      // per the spec, this could be caled with more arguments,
+      // but we just need `method` and `url` here. the rest are
+      // passed to `prevOpen` later.
+      function open(this: any, method: string, url: string): void {
+        const metadata = { method, url }
+
+        function onXhrLoad(this: XMLHttpRequest) {
+          appsignal.addBreadcrumb({
+            category:
+              this.status >= 400
+                ? `Request failed with code ${this.status}`
+                : `Recieved a response with code ${this.status}`,
+            action: "XMLHttpRequest",
+            metadata
+          })
+        }
+
+        function onXhrError(this: XMLHttpRequest) {
+          appsignal.addBreadcrumb({
+            category: "Request failed",
+            action: "XMLHttpRequest",
+            metadata
+          })
+        }
+
+        // set handlers
+        this.addEventListener("load", onXhrLoad)
+        this.addEventListener("error", onXhrError)
+
+        prevOpen.apply(this, arguments as any)
+      }
+
+      XMLHttpRequest.prototype.open = open
+    }
+
+    const fetchPatch = () => {
+      const appsignal = this
+      const originalFetch = window.fetch
+
+      function fetch(
+        input: RequestInfo,
+        init?: RequestInit
+      ): Promise<Response> {
+        const url = typeof input === "string" ? input : input.url
+
+        // Assume a GET request if we can't infer the method
+        const method =
+          (typeof input !== "string" && input.method) ||
+          (init && init.method) ||
+          "GET"
+
+        const metadata = {
+          method,
+          url
+        }
+
+        return originalFetch
+          .apply(window, arguments as any)
+          .then((response: Response) => {
+            // re-assign to fix some browsers not liking when you
+            // access `response.status` directly
+            const { status: statusCode } = response
+
+            appsignal.addBreadcrumb({
+              category: `Recieved a response with code ${statusCode}`,
+              action: "Fetch",
+              metadata
+            })
+
+            return response
+          })
+          .catch((error: Error) => {
+            appsignal.addBreadcrumb({
+              category: "Request failed",
+              action: "Fetch",
+              metadata
+            })
+
+            throw error
+          })
+      }
+
+      window.fetch = fetch
+    }
+
+    if (opts.xhrEnabled) xhrPatch()
+    if (opts.fetchEnabled) fetchPatch()
+  }
+}
+
+export const plugin = networkBreadcrumbsPlugin

--- a/packages/plugin-breadcrumbs-network/tsconfig.cjs.json
+++ b/packages/plugin-breadcrumbs-network/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/cjs",
+    "module": "commonjs"
+  }
+}

--- a/packages/plugin-breadcrumbs-network/tsconfig.esm.json
+++ b/packages/plugin-breadcrumbs-network/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/esm",
+    "module": "es6"
+  }
+}

--- a/packages/plugin-breadcrumbs-network/tsconfig.json
+++ b/packages/plugin-breadcrumbs-network/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*"],
+  "exclude": [
+    "src/**/__tests__",
+    "src/**/__mocks__"
+  ],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "target": "es5"
+  }
+}


### PR DESCRIPTION
This PR adds the `@appsignal/plugin-breadcrumbs-network` plugin, which wraps `XMLHttpRequest` and `fetch` in order to add breadcrumbs on every HTTP request from the browser.