### PR TITLE
Add ignored errors list

### DIFF
--- a/packages/javascript/src/__tests__/index.test.ts
+++ b/packages/javascript/src/__tests__/index.test.ts
@@ -28,6 +28,44 @@ describe("Appsignal", () => {
     expect(result.namespace).toEqual("test")
   })
 
+  it("recieves an array of ignored patterns if one is passed to the constructor", () => {
+    const ignored = [/Ignore me/gm]
+
+    appsignal = new Appsignal({
+      key: "TESTKEY",
+      namespace: "test",
+      ignore: ignored
+    })
+
+    expect(appsignal.ignored).toEqual(ignored)
+  })
+
+  describe("send", () => {
+    it("ignores an error that matches a regex in the ignored list", () => {
+      const name = "Ignore me"
+      const ignored = [/Ignore me/gm]
+
+      appsignal = new Appsignal({
+        key: "TESTKEY",
+        namespace: "test",
+        ignore: ignored
+      })
+
+      // monkeypatch console with mock fn
+      const original = console.warn
+      console.warn = jest.fn()
+
+      appsignal.send(new Error(name))
+
+      expect(console.warn).toBeCalledWith(
+        `[APPSIGNAL]: Ignored an error: ${name}`
+      )
+
+      // reset
+      console.warn = original
+    })
+  })
+
   describe("sendError", () => {
     it("pushes an error", () => {
       const message = "test error"

--- a/packages/javascript/src/__tests__/index.test.ts
+++ b/packages/javascript/src/__tests__/index.test.ts
@@ -34,7 +34,7 @@ describe("Appsignal", () => {
     appsignal = new Appsignal({
       key: "TESTKEY",
       namespace: "test",
-      ignore: ignored
+      ignoreErrors: ignored
     })
 
     expect(appsignal.ignored).toEqual(ignored)
@@ -48,7 +48,7 @@ describe("Appsignal", () => {
       appsignal = new Appsignal({
         key: "TESTKEY",
         namespace: "test",
-        ignore: ignored
+        ignoreErrors: ignored
       })
 
       // monkeypatch console with mock fn

--- a/packages/javascript/src/index.ts
+++ b/packages/javascript/src/index.ts
@@ -58,7 +58,7 @@ export default class Appsignal {
 
     // ignored exeptions are checked against the `message`
     // property of a given `Error`
-    this.ignored = options.ignore || []
+    this.ignored = options.ignoreErrors || []
 
     this._breadcrumbs = []
     this._dispatcher = new Dispatcher(this._queue, this._api)

--- a/packages/javascript/src/index.ts
+++ b/packages/javascript/src/index.ts
@@ -21,6 +21,8 @@ import { compose } from "./utils/functional"
 export default class Appsignal {
   public VERSION = VERSION
 
+  public ignored: RegExp[]
+
   private _dispatcher: Dispatcher
   private _options: AppsignalOptions
   private _api: PushApi
@@ -53,6 +55,10 @@ export default class Appsignal {
       uri,
       version: this.VERSION
     })
+
+    // ignored exeptions are checked against the `message`
+    // property of a given `Error`
+    this.ignored = options.ignore || []
 
     this._breadcrumbs = []
     this._dispatcher = new Dispatcher(this._queue, this._api)
@@ -103,6 +109,28 @@ export default class Appsignal {
         "[APPSIGNAL]: Can't send error, given error is not a valid type"
       )
       return
+    }
+
+    // handle user defined ignores
+    if (this.ignored.length !== 0) {
+      if (
+        data instanceof Error &&
+        this.ignored.some(el => el.test(data.message))
+      ) {
+        console.warn(`[APPSIGNAL]: Ignored an error: ${data.message}`)
+        return
+      }
+
+      if (data instanceof Span) {
+        const { error } = data.serialize()
+
+        // using the bang operator here as tsc doesnt recognise that we are
+        // checking for the value to be set as the first predicate
+        if (error.message && this.ignored.some(el => el.test(error.message!))) {
+          console.warn(`[APPSIGNAL]: Ignored a span: ${error.message}`)
+          return
+        }
+      }
     }
 
     // a "span" currently refers to a fixed point in time, as opposed to

--- a/packages/javascript/src/types/options.ts
+++ b/packages/javascript/src/types/options.ts
@@ -6,6 +6,7 @@ type BaseOptions = {
 export type AppsignalOptions = BaseOptions & {
   namespace?: string
   revision?: string
+  ignore?: RegExp[]
 }
 
 export type PushApiOptions = BaseOptions & {

--- a/packages/javascript/src/types/options.ts
+++ b/packages/javascript/src/types/options.ts
@@ -6,7 +6,7 @@ type BaseOptions = {
 export type AppsignalOptions = BaseOptions & {
   namespace?: string
   revision?: string
-  ignore?: RegExp[]
+  ignoreErrors?: RegExp[]
 }
 
 export type PushApiOptions = BaseOptions & {


### PR DESCRIPTION
Closes #11. 

Adds an `ignore` option that takes an array of `RegEx`s. If a given `Span` or `Error`'s message matches any of the patterns in the ignored list, the `Span` or `Error` is ignored.