### PR TITLE
Don't send span and rethrow when no key is supplied to constructor

### DIFF
--- a/packages/javascript/src/transports/xdomain.ts
+++ b/packages/javascript/src/transports/xdomain.ts
@@ -20,7 +20,7 @@ export class XDomainTransport implements ITransport {
 
       // XDomainRequest will only make a request to a URL with
       // the same protocol
-      req.open("POST", this.url.replace(rx, window.location.protocol))
+      req.open("POST", this.url.replace(rx, window?.location?.protocol))
 
       setTimeout(() => {
         try {

--- a/packages/javascript/src/types/options.ts
+++ b/packages/javascript/src/types/options.ts
@@ -1,5 +1,5 @@
 type BaseOptions = {
-  key: string
+  key?: string
   uri?: string
 }
 
@@ -10,5 +10,6 @@ export type AppsignalOptions = BaseOptions & {
 }
 
 export type PushApiOptions = BaseOptions & {
+  key: string
   version: string
 }


### PR DESCRIPTION
Closes #208. If no `key` is supplied to the constructor, the client will now output the span to the console and rethrow the error. 