### PR TITLE
Ignore URLs with option in plugin-breadcrumbs-network

### DIFF
--- a/packages/plugin-breadcrumbs-console/package.json
+++ b/packages/plugin-breadcrumbs-console/package.json
@@ -21,6 +21,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "@appsignal/javascript": "^1.2.1"
+  },
   "devDependencies": {
     "@appsignal/types": "^1.0.0"
   }

--- a/packages/plugin-breadcrumbs-network/package.json
+++ b/packages/plugin-breadcrumbs-network/package.json
@@ -18,6 +18,9 @@
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch"
   },
+  "dependencies": {
+    "@appsignal/javascript": "^1.2.1"
+  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
Fixes #259. URLs can now be ignored from `plugin-breadcrumbs-network`. If any of the URLs passed as `ignoreUrls` match the URL of the current request, no breadcrumb is added for it.

Example:

```
appsignal.use(plugin({
  ignoreUrls: [/api\.github\.com/]
}))
```