### PR TITLE
Add @appsignal/cli package and diagnose command wrapper

### DIFF
--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -1,0 +1,8 @@
+*-debug.log
+*-error.log
+/.nyc_output
+/dist
+/lib
+/package-lock.json
+/tmp
+node_modules

--- a/packages/cli/.npmignore
+++ b/packages/cli/.npmignore
@@ -1,0 +1,3 @@
+*
+!/dist/**/*
+*.tsbuildinfo

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 AppSignal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cli/bin/run
+++ b/packages/cli/bin/run
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+const { CLI } = require("../dist/index")
+const { name, version } = require("../package.json")
+
+/**
+ * @appsignal/cli
+ * 
+ * The CLI tool for all of AppSignal's JavaScript integrations for the browser
+ * and Node.js.
+ * 
+ * Need help with this tool? Contact support@appsignal.com
+ */
+const cli = new CLI({ name, version }).run()

--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "jsdom",
+  roots: [
+    "<rootDir>/src"
+  ],
+  transform: {
+    "^.+\\.tsx?$": "ts-jest"
+  },
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@appsignal/cli",
+  "version": "0.0.0",
+  "main": "./dist/index",
+  "repository": "git@github.com:appsignal/appsignal-javascript.git",
+  "author": "Adam Yeats <adam@appsignal.com>",
+  "license": "MIT",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "build:watch": "tsc -p tsconfig.json -w --preserveWatchOutput",
+    "clean": "rimraf dist coverage",
+    "link:yarn": "yarn link",
+    "test": "jest --passWithNoTests",
+    "test:watch": "jest --watch"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "tslib": "^2.0.1",
+    "chalk": "^4.1.0",
+    "commander": "^6.1.0",
+    "inquirer": "^7.3.3"
+  },
+  "bin": {
+    "cli": "./bin/run"
+  }
+}

--- a/packages/cli/src/commands/diagnose.ts
+++ b/packages/cli/src/commands/diagnose.ts
@@ -1,0 +1,61 @@
+import { spawn } from "child_process"
+
+/**
+ * Usage: npx @appsignal/cli diagnose [options]
+ *
+ * runs the diagnose command (Node.js integration only)
+ *
+ * Options:
+ * -e, --environment <env>  Which environment to use
+ * -k, --api-key <key>      Which API key to use
+ * -h, --help               display help for command
+ *
+ * This command just spawns the diagnose command from the `@appsignal/nodejs`
+ * package as a child process.
+ */
+export const diagnose = ({
+  apiKey,
+  environment
+}: {
+  apiKey?: string
+  environment?: string
+}): void => {
+  // some checks to ensure we are in the right place
+  try {
+    console.log("🔭 Checking your package.json for @appsignal/nodejs...")
+    const pkg = require(`${process.cwd()}/package.json`)
+
+    if (!("@appsignal/nodejs" in pkg.dependencies)) {
+      console.error("Couldn't find @appsignal/nodejs in your dependencies")
+      process.exit(1)
+    }
+
+    console.log("✅ Found it! Running the diagnose tool...")
+  } catch (e) {
+    console.error(
+      "Couldn't find a package.json in your current working directory"
+    )
+
+    process.exit(1)
+  }
+
+  if (apiKey) {
+    process.env["APPSIGNAL_PUSH_API_KEY"] = apiKey
+  }
+
+  if (environment) {
+    process.env["APPSIGNAL_APP_ENV"] = environment
+  }
+
+  const diag = spawn(
+    `${process.cwd()}/node_modules/@appsignal/nodejs/bin/diagnose`
+  )
+
+  diag.stdout.on("data", data => console.log(`${data}`))
+  diag.stderr.on("data", data => console.error(`${data}`))
+
+  diag.on("close", code => {
+    console.log(`Child process exited with code ${code}`)
+    process.exit(0)
+  })
+}

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -1,0 +1,3 @@
+export const install = (cmd: {}) => {
+  console.log("Not implemented.")
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,30 @@
+import commander, { Command } from "commander"
+
+import { install } from "./commands/install"
+import { diagnose } from "./commands/diagnose"
+
+export class CLI {
+  private cmd: commander.Command
+
+  constructor({ name, version }: { name: string; version: string }) {
+    this.cmd = new Command(name).version(version)
+  }
+
+  public run() {
+    this.cmd
+      .command("install [variant]")
+      .description("installs AppSignal")
+      .action(install)
+
+    this.cmd
+      .command("diagnose")
+      .description("runs the diagnose command (Node.js integration only)")
+      .option("-e, --environment <env>", "Which environment to use")
+      .option("-k, --api-key <key>", "Which API key to use")
+      .action(diagnose)
+
+    this.cmd.parse(process.argv)
+
+    return this
+  }
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*"],
+  "exclude": [
+    "src/**/__tests__",
+    "src/**/__mocks__"
+  ],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "target": "es5",
+    "outDir": "./dist",
+    "module": "commonjs"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2711,6 +2711,11 @@ cli-width@^2.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
   integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
 
+cli-width@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
+  integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
+
 cliui@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
@@ -2814,6 +2819,11 @@ commander@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.0.0.tgz#2b270da94f8fb9014455312f829a1129dbf8887e"
   integrity sha512-s7EA+hDtTYNhuXkTlhqew4txMZVdszBmKWSPEMxGr8ru8JXR7bLUFIAtPhcSuFdJQ0ILMxnJi8GkQL0yvDy/YA==
+
+commander@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.1.0.tgz#f8d722b78103141006b66f4c7ba1e97315ba75bc"
+  integrity sha512-wl7PNrYWd2y5mp1OK/LhTlv8Ff4kQJQRXXAvF+uU/TPNiVJUxZLRYGj/B0y/lPGAVcSbJqH2Za/cvHmrPMC8mA==
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -3755,7 +3765,7 @@ figures@^2.0.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
-figures@^3.2.0:
+figures@^3.0.0, figures@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
   integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
@@ -4461,6 +4471,25 @@ inquirer@^6.2.0:
     rxjs "^6.4.0"
     string-width "^2.1.0"
     strip-ansi "^5.1.0"
+    through "^2.3.6"
+
+inquirer@^7.3.3:
+  version "7.3.3"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.3.3.tgz#04d176b2af04afc157a83fd7c100e98ee0aad003"
+  integrity sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.19"
+    mute-stream "0.0.8"
+    run-async "^2.4.0"
+    rxjs "^6.6.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
     through "^2.3.6"
 
 ip-regex@^2.1.0:
@@ -5548,6 +5577,11 @@ lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.2.1:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
+lodash@^4.17.19:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
 log-symbols@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.0.0.tgz#69b3cc46d20f448eccdb75ea1fa733d9e821c920"
@@ -5938,7 +5972,7 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
-mute-stream@~0.0.4:
+mute-stream@0.0.8, mute-stream@~0.0.4:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
@@ -7252,6 +7286,11 @@ run-async@^2.2.0:
   dependencies:
     is-promise "^2.1.0"
 
+run-async@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
+  integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
+
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/run-queue/-/run-queue-1.0.3.tgz#e848396f057d223f24386924618e25694161ec47"
@@ -7263,6 +7302,13 @@ rxjs@^6.4.0, rxjs@^6.6.2:
   version "6.6.2"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.2.tgz#8096a7ac03f2cc4fe5860ef6e572810d9e01c0d2"
   integrity sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.6.0:
+  version "6.6.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
+  integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
This PR adds the `@appsignal/cli` package, which at the moment only has one function: a wrapper around the diagnose command for `@appsignal/nodejs`. Next step is to add the `install` command.