### PR TITLE
Fix typo recieve -> receive

### DIFF
--- a/packages/javascript/src/__tests__/index.test.ts
+++ b/packages/javascript/src/__tests__/index.test.ts
@@ -18,7 +18,7 @@ describe("Appsignal", () => {
     expect(appsignal.VERSION).toEqual(VERSION)
   })
 
-  it("recieves a namespace if one is passed to the constructor", () => {
+  it("receives a namespace if one is passed to the constructor", () => {
     appsignal = new Appsignal({ key: "TESTKEY", namespace: "test" })
 
     const span = appsignal.createSpan()
@@ -28,7 +28,7 @@ describe("Appsignal", () => {
     expect(result.namespace).toEqual("test")
   })
 
-  it("recieves an array of ignored patterns if one is passed to the constructor", () => {
+  it("receives an array of ignored patterns if one is passed to the constructor", () => {
     const ignored = [/Ignore me/gm]
 
     appsignal = new Appsignal({

--- a/packages/plugin-breadcrumbs-network/src/index.ts
+++ b/packages/plugin-breadcrumbs-network/src/index.ts
@@ -47,7 +47,7 @@ function networkBreadcrumbsPlugin(options?: Partial<PluginOptions>) {
               action:
                 this.status >= 400
                   ? `Request failed with code ${this.status}`
-                  : `Recieved a response with code ${this.status}`,
+                  : `Received a response with code ${this.status}`,
               category: "XMLHttpRequest",
               metadata
             })
@@ -106,7 +106,7 @@ function networkBreadcrumbsPlugin(options?: Partial<PluginOptions>) {
             const { status: statusCode } = response
 
             appsignal.addBreadcrumb({
-              action: `Recieved a response with code ${statusCode}`,
+              action: `Received a response with code ${statusCode}`,
               category: "Fetch",
               metadata
             })


### PR DESCRIPTION
Noticed a typo when looking at the breadcrumbs:

<img src="https://user-images.githubusercontent.com/729565/94019155-1b2e8780-fdba-11ea-9f95-4313912ef6c8.png" width="500" alt=""/>
