### PR TITLE
Improve the default error message if an invalid error object is passed to span.setError

### DIFF
--- a/packages/javascript/src/__tests__/span.test.ts
+++ b/packages/javascript/src/__tests__/span.test.ts
@@ -19,5 +19,42 @@ describe("Span", () => {
       span.setError((undefined as unknown) as Error)
       expect(span.serialize().error.message).toBe("No error has been set")
     })
+
+    describe("bad input", () => {
+      it("handles strings", () => {
+        span.setError(("a string" as unknown) as Error)
+        expect(span.serialize().error.message).toBe(
+          `setError received "a string", which did not provide an error message, or was not an object with a valid message property`
+        )
+      })
+
+      it("handles numbers", () => {
+        span.setError((123 as unknown) as Error)
+        expect(span.serialize().error.message).toBe(
+          `setError received "123", which did not provide an error message, or was not an object with a valid message property`
+        )
+      })
+
+      it("handles booleans", () => {
+        span.setError((true as unknown) as Error)
+        expect(span.serialize().error.message).toBe(
+          `setError received "true", which did not provide an error message, or was not an object with a valid message property`
+        )
+      })
+
+      it("handles arrays", () => {
+        span.setError(([] as unknown) as Error)
+        expect(span.serialize().error.message).toBe(
+          `setError received "[]", which did not provide an error message, or was not an object with a valid message property`
+        )
+      })
+
+      it("handles objects", () => {
+        span.setError(({} as unknown) as Error)
+        expect(span.serialize().error.message).toBe(
+          `setError received "{}", which did not provide an error message, or was not an object with a valid message property`
+        )
+      })
+    })
   })
 })

--- a/packages/javascript/src/span.ts
+++ b/packages/javascript/src/span.ts
@@ -40,7 +40,9 @@ export class Span extends Serializable<SpanData> {
       name: error.name || "Error",
       message:
         error.message ||
-        `setError received ${error}, which did not provide an error message, or was not an object with a valid message property`,
+        `setError received "${
+          typeof error !== "string" ? JSON.stringify(error) : error
+        }", which did not provide an error message, or was not an object with a valid message property`,
       backtrace: getStacktrace(error)
     }
 

--- a/packages/javascript/src/span.ts
+++ b/packages/javascript/src/span.ts
@@ -38,7 +38,9 @@ export class Span extends Serializable<SpanData> {
 
     this._data.error = {
       name: error.name || "Error",
-      message: error.message || "No message given",
+      message:
+        error.message ||
+        `setError received ${error}, which did not provide an error message, or was not an object with a valid message property`,
       backtrace: getStacktrace(error)
     }
 


### PR DESCRIPTION
This PR is following a support request where a customer was unable to determine the reason they were seeing a "No message given" default message regularly in their app. This message normally happens when the argument passed to `span.setError()`  doesn't have a `.message`  property, but it doesn't give the customer (or us) a way to find out what the cause of that might be.

This PR improves the message, and attempts to coerce the argument passed to `setError` to a string and interpolates that into the message.