### PR TITLE
Add Installer CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "@angular/core": "^10.1.3",
     "@testing-library/preact": "^2.0.0",
     "@testing-library/react": "^11.0.4",
+    "@types/inquirer": "^7.3.1",
     "@types/jest": "^26.0.14",
     "@types/node": "^14.11.2",
     "@types/react": "^16.9.49",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,10 +17,10 @@
     "access": "public"
   },
   "dependencies": {
-    "tslib": "^2.0.1",
     "chalk": "^4.1.0",
     "commander": "^6.1.0",
-    "inquirer": "^7.3.3"
+    "inquirer": "^7.3.3",
+    "tslib": "^2.0.1"
   },
   "bin": {
     "cli": "./bin/run"

--- a/packages/cli/src/commands/diagnose.ts
+++ b/packages/cli/src/commands/diagnose.ts
@@ -48,11 +48,12 @@ export const diagnose = ({
   }
 
   const diag = spawn(
-    `${process.cwd()}/node_modules/@appsignal/nodejs/bin/diagnose`
+    `${process.cwd()}/node_modules/@appsignal/nodejs/bin/diagnose`,
+    {
+      cwd: __dirname,
+      stdio: "inherit"
+    }
   )
-
-  diag.stdout.on("data", data => console.log(`${data}`))
-  diag.stderr.on("data", data => console.error(`${data}`))
 
   diag.on("close", code => {
     console.log(`Child process exited with code ${code}`)

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -1,3 +1,196 @@
-export const install = (cmd: {}) => {
-  console.log("Not implemented.")
+import { existsSync } from "fs"
+import { spawnSync } from "child_process"
+import chalk from "chalk"
+import inquirer from "inquirer"
+
+const SUPPORTED_NODEJS_INTEGRATIONS: { [key: string]: string } = {
+  express: "@appsignal/express",
+  next: "@appsignal/nextjs",
+  "apollo-server": "@appsignal/apollo-server",
+  "apollo-server-express": "@appsignal/apollo-server"
+}
+
+async function installNode(pkg: { [key: string]: any }) {
+  const { apiKey } = await inquirer.prompt([
+    {
+      type: "input",
+      name: "apiKey",
+      message: "What's your Push API Key?"
+    }
+  ])
+
+  // detect if user is using yarn
+  const isUsingYarn = existsSync(`${process.cwd()}/yarn.lock`)
+
+  const modules = Object.keys(pkg.dependencies)
+    .map(dep => SUPPORTED_NODEJS_INTEGRATIONS[dep])
+    .filter(dep => dep)
+
+  console.log() // blank line
+
+  console.log(
+    `We found ${chalk.cyan(modules.length)} integration${
+      modules.length !== 1 ? "s" : ""
+    } for the modules that you currently have installed:`
+  )
+
+  console.log() // blank line
+
+  modules.forEach(mod => console.log(`${mod}`))
+
+  console.log() // blank line
+
+  const { shouldInstallNow } = await inquirer.prompt([
+    {
+      type: "confirm",
+      name: "shouldInstallNow",
+      message: "Do you want to install these now?",
+      default: true
+    }
+  ])
+
+  console.log() // blank line
+
+  modules.unshift("@appsignal/nodejs")
+
+  if (shouldInstallNow) {
+    if (isUsingYarn) {
+      // using yarn
+      spawnSync("yarn", ["add", ...modules], {
+        cwd: process.cwd(),
+        stdio: "inherit"
+      })
+    } else {
+      // using npm
+      spawnSync("npm", ["install", "--save", ...modules], {
+        cwd: process.cwd(),
+        stdio: "inherit"
+      })
+    }
+  } else {
+    console.log(`OK! We won't install anything right now.`)
+
+    console.log(
+      `You can add these packages later by running:`,
+      chalk.bold(
+        isUsingYarn
+          ? `yarn add ${modules.join(" ")}`
+          : `npm install --save ${modules.join(" ")}`
+      )
+    )
+  }
+
+  console.log() // blank line
+
+  console.log(`🎉 Great news! You've just installed AppSignal to your project!`)
+
+  console.log() // blank line
+
+  console.log(
+    `The next step is adding your Push API key to your project. The best way to do this is with an environment variable:`
+  )
+
+  console.log() // blank line
+
+  console.log(chalk.bold(`export APPSIGNAL_PUSH_API_KEY="${apiKey}"`))
+
+  console.log() // blank line
+
+  console.log(
+    `If you're using a cloud provider such as Heroku etc., seperate instructions on how to add these environment variables are available in our documentation:`
+  )
+
+  console.log() // blank line
+
+  console.log(`https://docs.appsignal.com/nodejs/configuration`)
+
+  console.log() // blank line
+
+  console.log(
+    `Then, you'll need to initalize AppSignal in your app. Please ensure that this is done in the entrypoint of your application, ${chalk.cyan(
+      "before all other dependencies are imported!"
+    )}`
+  )
+
+  console.log() // blank line
+
+  console.log(
+    chalk.bold(
+      `const { Appsignal } = require("@appsignal/nodejs");\n\nconst appsignal = new Appsignal({\n  active: true, \n  name: "<YOUR APPLICATION NAME>"\n});`
+    )
+  )
+
+  console.log() // blank line
+
+  console.log(
+    `Some integrations require additional setup. See https://docs.appsignal.com/nodejs/integrations/ for more information.`
+  )
+
+  console.log() // blank line
+
+  console.log(
+    `Need any further help? Feel free to ask a human at ${chalk.bold(
+      "support@appsignal.com"
+    )}!`
+  )
+}
+
+/**
+ * Usage: @appsignal/cli install [options]
+ *
+ * installs AppSignal
+ *
+ * Options:
+ * -h, --help  display help for command
+ */
+export async function install() {
+  let pkg: { [key: string]: any }
+
+  console.log("🚀 Alright! Let's install AppSignal to your project!")
+
+  try {
+    console.log("🔭 Checking for your package.json...")
+    pkg = require(`${process.cwd()}/package.json`)
+
+    console.log("✅ Found it!")
+  } catch (e) {
+    console.error(
+      "Couldn't find a package.json in your current working directory"
+    )
+
+    throw e
+  }
+
+  try {
+    const { integration } = await inquirer.prompt([
+      {
+        type: "list",
+        name: "integration",
+        message: "Which integration do you need?",
+        choices: [
+          "Node.js",
+          {
+            name: "Browser",
+            disabled: "Unavailable at this time"
+          }
+        ],
+        filter: val => val.toLowerCase().split(".").join("")
+      }
+    ])
+
+    if (integration === "nodejs") {
+      await installNode(pkg)
+    }
+
+    console.log("\n✅ Done!")
+    return
+  } catch (error) {
+    if (error.isTtyError) {
+      console.warn(
+        "Prompt couldn't be rendered in the current environment, exiting..."
+      )
+    }
+
+    throw error
+  }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,7 +12,7 @@ export class CLI {
 
   public run() {
     this.cmd
-      .command("install [variant]")
+      .command("install")
       .description("installs AppSignal")
       .action(install)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1512,6 +1512,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/inquirer@^7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@types/inquirer/-/inquirer-7.3.1.tgz#1f231224e7df11ccfaf4cf9acbcc3b935fea292d"
+  integrity sha512-osD38QVIfcdgsPCT0V3lD7eH0OFurX71Jft18bZrsVQWVRt6TuxRzlr0GJLrxoHZR2V5ph7/qP8se/dcnI7o0g==
+  dependencies:
+    "@types/through" "*"
+    rxjs "^6.4.0"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -1619,6 +1627,13 @@
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.5.tgz#9adbc12950582aa65ead76bffdf39fe0c27a3c02"
   integrity sha512-/gG2M/Imw7cQFp8PGvz/SwocNrmKFjFsm5Pb8HdbHkZ1K8pmuPzOX4VeVoiEecFCVf4CsN1r3/BRvx+6sNqwtQ==
+
+"@types/through@*":
+  version "0.0.30"
+  resolved "https://registry.yarnpkg.com/@types/through/-/through-0.0.30.tgz#e0e42ce77e897bd6aead6f6ea62aeb135b8a3895"
+  integrity sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==
+  dependencies:
+    "@types/node" "*"
 
 "@types/uglify-js@*":
   version "3.0.5"


### PR DESCRIPTION
Closes https://github.com/appsignal/appsignal-nodejs/issues/131.

This PR adds an installer CLI, that can be used by calling `npx @appsignal/cli install`.

<img width="1301" alt="Screenshot 2020-09-28 at 15 22 28" src="https://user-images.githubusercontent.com/16296989/94437846-99b26d00-019e-11eb-8f52-1b7dfa16e15e.png">
