### PR TITLE
Fix onunhandledrejection behavior in plugin-window-events

### DIFF
--- a/packages/plugin-window-events/src/__tests__/index.test.ts
+++ b/packages/plugin-window-events/src/__tests__/index.test.ts
@@ -15,6 +15,10 @@ describe("windowEventsPlugin", () => {
     send: jest.fn()
   } as unknown) as JSClient
 
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   it("responds to options object", () => {
     const opts = {
       onerror: false,
@@ -68,7 +72,7 @@ describe("windowEventsPlugin", () => {
       expect(setErrorMock).toHaveBeenCalledWith({
         name: "UnhandledPromiseRejectionError",
         message: "test",
-        stack: ""
+        stack: "No stacktrace available"
       })
     })
 
@@ -86,6 +90,34 @@ describe("windowEventsPlugin", () => {
         name: "UnhandledPromiseRejectionError",
         message: "{}",
         stack: error.stack
+      })
+    })
+
+    it("can handle a promise rejection without a reason", () => {
+      plugin({}).call(mockAppsignal)
+
+      ctx.onunhandledrejection!({} as PromiseRejectionEvent)
+
+      expect(mockAppsignal.createSpan).toHaveBeenCalled()
+
+      expect(setErrorMock).toHaveBeenCalledWith({
+        name: "UnhandledPromiseRejectionError",
+        message: undefined,
+        stack: "No stacktrace available"
+      })
+    })
+
+    it("can handle a promise rejection without an argument", () => {
+      plugin({}).call(mockAppsignal)
+
+      ctx.onunhandledrejection!((undefined as unknown) as PromiseRejectionEvent)
+
+      expect(mockAppsignal.createSpan).toHaveBeenCalled()
+
+      expect(setErrorMock).toHaveBeenCalledWith({
+        name: "UnhandledPromiseRejectionError",
+        message: undefined,
+        stack: "No stacktrace available"
       })
     })
   })

--- a/packages/plugin-window-events/src/index.ts
+++ b/packages/plugin-window-events/src/index.ts
@@ -72,12 +72,12 @@ function windowEventsPlugin(options?: { [key: string]: any }) {
       span.setError({
         name: "UnhandledPromiseRejectionError",
         message:
-          typeof error.reason === "string"
+          error && typeof error.reason === "string"
             ? error.reason
-            : JSON.stringify(error.reason),
+            : JSON.stringify(error?.reason),
         // if `reason` is an instance of `Error`, then it may contain
         // a stack. we try to get it here, or just return an empty string
-        stack: error.reason.stack || ""
+        stack: error?.reason?.stack || "No stacktrace available"
       })
 
       self.send(span)


### PR DESCRIPTION
This PR fixes a bug where, if the `window.onunhandledrejection` is called without an argument, or with an object with a different interface than the one specified (`PromiseRejectionEvent`), the plugin would throw an error.

Fixes #452.