### PR TITLE
Increase maximum sourcemap size limit webpack

### DIFF
--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -55,7 +55,7 @@ export class AppsignalPlugin implements WebpackPluginInstance {
     this._request = axios.create({
       baseURL: endpoint,
       timeout,
-      maxBodyLength: Math.floor(16 * 1000000) // 16MB, the max allowed on the server
+      maxBodyLength: Math.floor(100 * 1000000) // 100MB, the max allowed on the server
     })
 
     this.options = options


### PR DESCRIPTION
Increase max sourcemap size for the webpack sourcemap upload plugin

16MB is a too low of a limit for some webpacks, his prevents users to from uploading sourcemap files.

We've increased the size to 100MB