### PR TITLE
[Feature] Add url to tags

### DIFF
--- a/packages/react/src/ErrorBoundary.tsx
+++ b/packages/react/src/ErrorBoundary.tsx
@@ -5,7 +5,8 @@ export class ErrorBoundary extends React.Component<Props, State> {
   state = { error: undefined }
 
   static defaultProps = {
-    action: ""
+    action: "",
+    addUrls: false
   }
 
   static getDerivedStateFromError(error: Error): State {
@@ -16,6 +17,7 @@ export class ErrorBoundary extends React.Component<Props, State> {
     const { instance: appsignal, action, tags = {} } = this.props
     const span = appsignal.createSpan()
 
+    if (addUrls) tags.currentUrl ||= window.location.href
     span.setError(error).setTags({ framework: "React", ...tags })
 
     if (action && action !== "") span.setAction(action)

--- a/packages/react/src/types/component.ts
+++ b/packages/react/src/types/component.ts
@@ -3,6 +3,7 @@ import type { JSClient } from "@appsignal/types"
 export type Props = {
   instance: JSClient
   action?: string
+  addUrl?: boolean
   children: React.ReactNode
   fallback?: Function
   tags?: { [key: string]: string }


### PR DESCRIPTION
We've noticed that for debugging front-end errors, its extremely useful if you know from which page the error was thrown. Hopefully this fix makes this easier to check.