### PR TITLE
Catch JSON.stringify circular structure error

### DIFF
--- a/packages/plugin-window-events/src/__tests__/index.test.ts
+++ b/packages/plugin-window-events/src/__tests__/index.test.ts
@@ -93,6 +93,29 @@ describe("windowEventsPlugin", () => {
       })
     })
 
+    it("handles a promise rejection with an circular structure as a reason", () => {
+      console.error = jest.fn()
+
+      plugin({}).call(mockAppsignal)
+
+      // Create circular reference in the reason object
+      const reason = { abc: "def", foo: "bar", reason: {} }
+      reason.reason = reason
+      ctx.onunhandledrejection!({ reason } as PromiseRejectionEvent)
+
+      expect(mockAppsignal.createSpan).toHaveBeenCalled()
+
+      expect(setErrorMock).toHaveBeenCalledWith({
+        name: "UnhandledPromiseRejectionError",
+        message: undefined,
+        stack: "No stacktrace available"
+      })
+      expect(console.error).toHaveBeenCalledWith(
+        "Could not serialize error reason to String.",
+        expect.any(Error)
+      )
+    })
+
     it("can handle a promise rejection without a reason", () => {
       plugin({}).call(mockAppsignal)
 

--- a/packages/plugin-window-events/src/index.ts
+++ b/packages/plugin-window-events/src/index.ts
@@ -71,10 +71,7 @@ function windowEventsPlugin(options?: { [key: string]: any }) {
 
       span.setError({
         name: "UnhandledPromiseRejectionError",
-        message:
-          error && typeof error.reason === "string"
-            ? error.reason
-            : JSON.stringify(error?.reason),
+        message: _reasonFromError(error),
         // if `reason` is an instance of `Error`, then it may contain
         // a stack. we try to get it here, or just return an empty string
         stack: error?.reason?.stack || "No stacktrace available"
@@ -93,6 +90,22 @@ function windowEventsPlugin(options?: { [key: string]: any }) {
 
     if (opts.onunhandledrejection) {
       ctx.onunhandledrejection = _onUnhandledRejectionHandler
+    }
+  }
+
+  function _reasonFromError(error: PromiseRejectionEvent) {
+    if (!error) {
+      return undefined
+    }
+    if (typeof error.reason === "string") {
+      return error.reason
+    }
+
+    try {
+      return JSON.stringify(error.reason)
+    } catch (e) {
+      console.error("Could not serialize error reason to String.", e)
+      return undefined
     }
   }
 }


### PR DESCRIPTION
When a PromiseRejectionEvent has a reason (error object) that contains a
circular structure the `JSON.stringify` function will throw an error.
This break the app because of something we don't handle, so let's catch
the error instead.

First reported in https://github.com/appsignal/support/issues/149

I moved the error reason handling to its own function so it's easier to
read than a (single line) ternary statement. This also makes it easier
to wrap only the `JSON.stringify` in a try-catch-statement.