### PR TITLE
Update tracer rootSpan returning type

### DIFF
--- a/packages/types/.changesets/tracer-does-not-return-rootspan-as-undefined-anymore.md
+++ b/packages/types/.changesets/tracer-does-not-return-rootspan-as-undefined-anymore.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Tracer rootSpan does not return undefined anymore, but returns a NoopSpan instead.

--- a/packages/types/src/interfaces/tracer.ts
+++ b/packages/types/src/interfaces/tracer.ts
@@ -32,11 +32,11 @@ export interface Tracer {
   currentSpan(): NodeSpan
 
   /**
+   *
    * Returns the root Span.
    *
-   * If there is no root Span available, `undefined` is returned.
    */
-  rootSpan(): NodeSpan | undefined
+  rootSpan(): NodeSpan
 
   /**
    * Adds the given error to the root Span.


### PR DESCRIPTION
Tracer rootSpan() was able to return undefined when called. This
collides with modules that use this type. Now it's only able to return
the NodeSpan type.