### PR TITLE
Rename addError NodeJS helpers to setError

### DIFF
--- a/packages/types/.changesets/rename-adderror-helper-functions-to-seterror-in-nodejs.md
+++ b/packages/types/.changesets/rename-adderror-helper-functions-to-seterror-in-nodejs.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Rename addError helper functions to setError in NodeJS

--- a/packages/types/src/interfaces/span.ts
+++ b/packages/types/src/interfaces/span.ts
@@ -76,9 +76,9 @@ export interface NodeSpan {
   child(): NodeSpan
 
   /**
-   * Adds a given `Error` object to the current `Span`.
+   * Sets a given `Error` object to the current `Span`.
    */
-  addError(error: Error): this
+  setError(error: Error): this
 
   /**
    * Sets a data collection as sample data on the current `Span`.

--- a/packages/types/src/interfaces/tracer.ts
+++ b/packages/types/src/interfaces/tracer.ts
@@ -43,7 +43,7 @@ export interface Tracer {
    *
    * If there is no root Span available to add the error, `undefined` is returned.
    */
-  addError(error: Error): NodeSpan | undefined
+  setError(error: Error): NodeSpan | undefined
 
   /**
    * Executes a given function asynchronously within the context of a given


### PR DESCRIPTION
In order to comply with AppSignal naming rules, we rename the addError
NodeJS helpers to setError