### PR TITLE
Deprecate addError helper for Node.js spans

### DIFF
--- a/packages/types/.changesets/deprecate-adderror-helper-for-spans.md
+++ b/packages/types/.changesets/deprecate-adderror-helper-for-spans.md
@@ -1,0 +1,8 @@
+---
+bump: "patch"
+---
+
+Deprecate addError helper for spans
+
+Errors are now added through the tracer in the NodeJS integration
+using the `setError` function. `span.addError()` is not used anymore.

--- a/packages/types/.changesets/deprecate-adderror-helper-for-spans.md
+++ b/packages/types/.changesets/deprecate-adderror-helper-for-spans.md
@@ -4,5 +4,5 @@ bump: "patch"
 
 Deprecate addError helper for spans
 
-Errors are now added through the tracer in the NodeJS integration
+Errors are now added through the tracer in the Node.js integration
 using the `setError` function. `span.addError()` is not used anymore.

--- a/packages/types/src/interfaces/span.ts
+++ b/packages/types/src/interfaces/span.ts
@@ -81,7 +81,7 @@ export interface NodeSpan {
   setError(error: Error): this
 
   /**
-   * @deprecated since NodeJS version 2.1.0
+   * @deprecated since Node.js version 2.1.0
    * Use `setError` instead
    */
   addError(error: Error): this

--- a/packages/types/src/interfaces/span.ts
+++ b/packages/types/src/interfaces/span.ts
@@ -81,6 +81,12 @@ export interface NodeSpan {
   setError(error: Error): this
 
   /**
+   * @deprecated since NodeJS version 2.1.0
+   * Use `setError` instead
+   */
+  addError(error: Error): this
+
+  /**
    * Sets a data collection as sample data on the current `Span`.
    */
   setSampleData(


### PR DESCRIPTION
Errors are now added through the tracer in the NodeJS integration
using the `setError` function. `span.addError()` is not used anymore.