### PR TITLE
Make sendError callback arg optional in Tracer

### DIFF
--- a/packages/types/.changesets/make-senderror-callback-argument-optional-for-node-tracer.md
+++ b/packages/types/.changesets/make-senderror-callback-argument-optional-for-node-tracer.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Make sendError callback argument optional for Node.js Tracer.

--- a/packages/types/src/interfaces/tracer.ts
+++ b/packages/types/src/interfaces/tracer.ts
@@ -52,7 +52,7 @@ export interface Tracer {
    * The created `RootSpan` is passed as the single argument to the given function.
    * This allows you to add arbitrary metadata to it.
    */
-  sendError<T>(error: Error, fn: (s: NodeSpan) => T): void
+  sendError<T>(error: Error, fn?: (s: NodeSpan) => T): void
 
   /**
    * Executes a given function asynchronously within the context of a given


### PR DESCRIPTION
`sendError()` helper for Node Tracer object accepts a callback function to
add metadata to the span. It needs to be optional to fit in the
situations where no metadata is required.