### PR TITLE
Add callback argument to sendError and wrap

### DIFF
--- a/packages/javascript/.changesets/add-callback-argument-to-senderror.md
+++ b/packages/javascript/.changesets/add-callback-argument-to-senderror.md
@@ -1,0 +1,24 @@
+---
+bump: "patch"
+---
+
+Add callback argument to the `sendError` function to allow for more customization of errors sent with `sendError` and `wrap`. The `tags` and `namespace` parameters are now deprecated for both helpers.
+
+```js
+// Deprecated behavior
+appsignal.sendError(
+  new Error("sendError with tags and namespace argument"),
+  { tag1: "value 1", tag2: "value 2" },
+  "custom_namespace"
+);
+
+// New behavior
+appsignal.sendError(
+  new Error("sendError with callback argument"),
+  function(span) {
+    span.setAction("SendErrorTestAction");
+    span.setNamespace("custom_namespace");
+    span.setTags({ tag1: "value 1", tag2: "value 2" });
+  }
+);
+```

--- a/packages/types/.changesets/add-callback-argument-to-senderror.md
+++ b/packages/types/.changesets/add-callback-argument-to-senderror.md
@@ -1,0 +1,24 @@
+---
+bump: "patch"
+---
+
+Add callback argument to the `sendError` function to allow for more customization of errors sent with `sendError` and `wrap`. The `tags` and `namespace` parameters are now deprecated for both helpers.
+
+```js
+// Deprecated behavior
+appsignal.sendError(
+  new Error("sendError with tags and namespace argument"),
+  { tag1: "value 1", tag2: "value 2" },
+  "custom_namespace"
+);
+
+// New behavior
+appsignal.sendError(
+  new Error("sendError with callback argument"),
+  function(span) {
+    span.setAction("SendErrorTestAction");
+    span.setNamespace("custom_namespace");
+    span.setTags({ tag1: "value 1", tag2: "value 2" });
+  }
+);
+```

--- a/packages/types/src/interfaces/client.ts
+++ b/packages/types/src/interfaces/client.ts
@@ -90,6 +90,11 @@ export interface JSClient extends BaseClient {
   /**
    * Records and sends a browser `Error` to AppSignal.
    */
+  send<T>(error: Error, fn?: (span: JSSpan) => T): Promise<JSSpan> | void
+
+  /**
+   * Records and sends a browser `Error` to AppSignal.
+   */
   send(error: Error, tags?: object, namespace?: string): Promise<JSSpan> | void
 
   /**
@@ -102,6 +107,9 @@ export interface JSClient extends BaseClient {
     tags?: object,
     namespace?: string
   ): Promise<any> | void
+
+  sendError<T>(error: Error): Promise<JSSpan> | void
+  sendError<T>(error: Error, fn?: (span: JSSpan) => T): Promise<JSSpan> | void
 
   /**
    * Records and sends a browser `Error` to AppSignal. An alias to `#send()`
@@ -126,6 +134,13 @@ export interface JSClient extends BaseClient {
    * Creates a new `Span`, augmented with the current environment.
    */
   createSpan(fn?: (span: JSSpan) => void): JSSpan
+
+  /**
+   * Wraps and catches errors within a given function. If the function throws an
+   * error, a rejected `Promise` will be returned and the error thrown will be
+   * logged to AppSignal.
+   */
+  wrap<T>(fn: () => T, callbackFn?: (span: JSSpan) => T): Promise<T>
 
   /**
    * Wraps and catches errors within a given function. If the function throws an


### PR DESCRIPTION
Currently the `sendError` functions (and in turn the `wrap` helper) has
`tags` and `namespace` parameters. We've seen in the past that this is
quite limiting for the `sendError` helper as users can't add additional
metadata like an action name, parameters, etc.

Deprecate the `tags` and `namespace` parameters in favor of the new
callback function. The deprecations will log a warning to the console
when it's detected they are used. I've not disabled their functionality
so users can upgrade at their own pace.

I'm not very familiar with TypeScript definitions so I've done my best
with what I saw in the rest of the library and found in the docs. The
`tags` parameter in the `send` and `sendError` functions now serves the
double purpose of `tags` parameter and callback function. I've done my
best to differentiate between these two function signatures by defining
multiple signatures.

The thing that was most unclear to me was passing the multi purpose
parameter as a HashMap to the `setTags` function. I ended up casting it
to a HashMap with the `toHashMap` function I saw used elsewhere, only
here I also needed to cast it explicitly to a `HashMap`, hence the
import.

Part of appsignal/integration-guide#41
We also need to update the docs.