### PR TITLE
Add tests for Angular package

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -15,7 +15,7 @@
     "build:watch": "run-p build:cjs:watch build:esm:watch",
     "clean": "rimraf dist coverage",
     "link:yarn": "yarn link",
-    "test": "jest --passWithNoTests",
+    "test": "jest",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/angular/src/__tests__/index.test.ts
+++ b/packages/angular/src/__tests__/index.test.ts
@@ -1,0 +1,33 @@
+import { AppsignalErrorHandler } from "../index"
+
+describe("Angular handleError", () => {
+  let appsignal: any
+
+  const mock: any = {
+    setError: jest.fn(() => mock),
+    setTags: jest.fn(() => mock)
+  }
+
+  const SpanMock = jest.fn().mockImplementation(() => mock)
+
+  beforeEach(() => {
+    appsignal = {
+      createSpan: () => new SpanMock(),
+      send: jest.fn()
+    }
+  })
+
+  it("calls AppSignal helper methods", () => {
+    const err = new Error("test")
+    const errorHandler = new AppsignalErrorHandler(appsignal)
+
+    errorHandler.handleError(err)
+
+    expect(mock.setError).toBeCalledWith(err)
+    expect(mock.setTags).toBeCalledWith({
+      framework: "Angular"
+    })
+
+    expect(appsignal.send).toBeCalledWith(mock)
+  })
+})


### PR DESCRIPTION
Angular package had no tests. This commits adds a simple one to test the
error handler class with mocks to see if AppSignal is called properly.

[skip changeset]