### PR TITLE
Refactor Git lint script

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -20,14 +20,10 @@ blocks:
   - name: Linters
     dependencies: []
     task:
-      env_vars:
-        - name: LINTJE_VERSION
-          value: "0.2.0"
       jobs:
         - name: Git Lint (Lintje)
           commands:
-            - script/install_lintje
-            - $HOME/bin/lintje $SEMAPHORE_GIT_COMMIT_RANGE
+            - script/lint_git
   - name: "Install and Build"
     dependencies: []
     task:

--- a/script/lint_git
+++ b/script/lint_git
@@ -2,6 +2,8 @@
 
 set -eu
 
+LINTJE_VERSION="0.4.1"
+
 mkdir -p $HOME/bin
 cache_key=v1-lintje-$LINTJE_VERSION
 cache restore $cache_key
@@ -16,3 +18,5 @@ else
     tar -xz --directory $HOME/bin
   cache store $cache_key $HOME/bin/lintje
 fi
+
+$HOME/bin/lintje $SEMAPHORE_GIT_COMMIT_RANGE


### PR DESCRIPTION
Having all Git lint related parts in one script improves maintainance
tasks, and prevents us from modifying extra files when updating the
matrix.

[skip changeset]