### PR TITLE
Include bin directory in distributed package

### DIFF
--- a/packages/cli/.changesets/fix-cli-commands.md
+++ b/packages/cli/.changesets/fix-cli-commands.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Fix the "install" and "diagnose" cli commands by including the bin wrapper in the distributed package.

--- a/packages/cli/.npmignore
+++ b/packages/cli/.npmignore
@@ -1,3 +1,4 @@
 *
+!/bin/*
 !/dist/**/*
 *.tsbuildinfo


### PR DESCRIPTION
We ran into the issue that the npx commands don't work.

```
$ npx @appsignal/cli install
sh: 1: cli: not found
$ npx @appsignal/cli diagnose
sh: 1: cli: not found
```

It appears that `cli` in the error message refers to the `bin` config in
`package.json`.

I downloaded the `@appsignal/cli` package and looked at what was
included, but the `bin` directory was missing. This change makes sure
it's included in the next release, in the same way we include the `dist`
directory.

I didn't get a chance to test this works, because locally I can't test
if the `bin` package is included or not.