### PR TITLE
Add testing for plugin-breadcrumbs-plugin

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -109,6 +109,9 @@ blocks:
     - name: "@appsignal/javascript - javascript"
       commands:
       - mono test --package=@appsignal/javascript
+    - name: "@appsignal/plugin-breadcrumbs-console - plugin-breadcrumbs-console"
+      commands:
+      - mono test --package=@appsignal/plugin-breadcrumbs-console
     - name: "@appsignal/plugin-window-events - plugin-window-events"
       commands:
       - mono test --package=@appsignal/plugin-window-events

--- a/packages/plugin-breadcrumbs-console/src/__tests__/index.test.ts
+++ b/packages/plugin-breadcrumbs-console/src/__tests__/index.test.ts
@@ -1,0 +1,115 @@
+import type { JSClient } from "@appsignal/types"
+import { plugin } from "../index"
+
+describe("BreadcrumbsConsolePlugin", () => {
+  const logMock = jest.spyOn(console, "log").mockImplementation(() => {})
+  const debugMock = jest.spyOn(console, "debug").mockImplementation(() => {})
+  const infoMock = jest.spyOn(console, "info").mockImplementation(() => {})
+  const warnMock = jest.spyOn(console, "warn").mockImplementation(() => {})
+  const errorMock = jest.spyOn(console, "error").mockImplementation(() => {})
+  const addBreadcrumb = jest.fn()
+
+  const mockAppsignal = ({ addBreadcrumb } as unknown) as JSClient
+  plugin({}).call(mockAppsignal)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("when console.log is called", () => {
+    it("adds breadcrumb", () => {
+      const message = "This is a log message"
+      console.log(message)
+
+      expect(logMock).toHaveBeenCalledWith(message)
+      expect(addBreadcrumb).toHaveBeenCalledWith({
+        action: "Console logged a value",
+        category: "console.log",
+        metadata: {
+          argument0: message
+        }
+      })
+    })
+  })
+
+  describe("when console.debug is called", () => {
+    it("adds breadcrumb", () => {
+      const message = "This is a debug message"
+      console.debug(message)
+
+      expect(debugMock).toHaveBeenCalledWith(message)
+      expect(addBreadcrumb).toHaveBeenCalledWith({
+        action: "Console logged a value",
+        category: "console.debug",
+        metadata: {
+          argument0: message
+        }
+      })
+    })
+  })
+
+  describe("when console.info is called", () => {
+    it("adds breadcrumb", () => {
+      const message = "This is an info message"
+      console.info(message)
+
+      expect(infoMock).toHaveBeenCalledWith(message)
+      expect(addBreadcrumb).toHaveBeenCalledWith({
+        action: "Console logged a value",
+        category: "console.info",
+        metadata: {
+          argument0: message
+        }
+      })
+    })
+  })
+
+  describe("when console.warn is called", () => {
+    it("adds breadcrumb", () => {
+      const message = "This is a warn message"
+      console.warn(message)
+
+      expect(warnMock).toHaveBeenCalledWith(message)
+      expect(addBreadcrumb).toHaveBeenCalledWith({
+        action: "Console logged a value",
+        category: "console.warn",
+        metadata: {
+          argument0: message
+        }
+      })
+    })
+  })
+
+  describe("when console.error is called", () => {
+    it("adds breadcrumb", () => {
+      const message = "This is an error message"
+      console.error(message)
+
+      expect(errorMock).toHaveBeenCalledWith(message)
+      expect(addBreadcrumb).toHaveBeenCalledWith({
+        action: "Console logged a value",
+        category: "console.error",
+        metadata: {
+          argument0: message
+        }
+      })
+    })
+  })
+
+  describe("when console function is called with multiple arguments", () => {
+    it("adds breadcrumb with multiple arguments", () => {
+      console.log("a", "b", 3)
+
+      expect(logMock).toHaveBeenCalledWith("a", "b", 3)
+      expect(addBreadcrumb).toHaveBeenCalledWith({
+        action: "Console logged some values",
+        category: "console.log",
+        metadata: {
+          argument0: "a",
+          argument1: "b",
+          argument2: "3"
+        }
+      })
+    })
+  })
+})


### PR DESCRIPTION
Add missing tests for this plugin so that we can debug issues with it
more easily later.

[skip changeset] because it's only adding tests.