### PR TITLE
Fix serialization of circular structures of values

### DIFF
--- a/packages/plugin-breadcrumbs-console/.changesets/fix-circular-structure-console-arguments.md
+++ b/packages/plugin-breadcrumbs-console/.changesets/fix-circular-structure-console-arguments.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Fix the error that was thrown when a circular structure console argument was logged. It will no longer throw the error and instead send a replacement value of the value that could not be send as a JSON value.

--- a/packages/plugin-breadcrumbs-console/src/__tests__/index.test.ts
+++ b/packages/plugin-breadcrumbs-console/src/__tests__/index.test.ts
@@ -112,4 +112,43 @@ describe("BreadcrumbsConsolePlugin", () => {
       })
     })
   })
+
+  describe("when console function is called with a normal object argument", () => {
+    it("adds breadcrumb without argument", () => {
+      const obj = { value1: "abc", nested: { value2: "def" } }
+      console.log(obj)
+
+      expect(logMock).toHaveBeenCalledWith(obj)
+      expect(errorMock).not.toHaveBeenCalled()
+      expect(addBreadcrumb).toHaveBeenCalledWith({
+        action: "Console logged a value",
+        category: "console.log",
+        metadata: {
+          argument0: `{"value1":"abc","nested":{"value2":"def"}}`
+        }
+      })
+    })
+  })
+
+  describe("when console function is called with a circular argument", () => {
+    it("adds breadcrumb without argument", () => {
+      const obj: { [key: string]: string | object } = { value1: "abc" }
+      obj.obj = obj
+      console.log(obj)
+
+      expect(logMock).toHaveBeenCalledWith(obj)
+      expect(errorMock).toHaveBeenCalledTimes(1)
+      expect(errorMock).toHaveBeenCalledWith(
+        'Could not serialize "console.log" to String.',
+        expect.any(Error)
+      )
+      expect(addBreadcrumb).toHaveBeenCalledWith({
+        action: "Console logged a value",
+        category: "console.log",
+        metadata: {
+          argument0: "[Value could not be serialized]"
+        }
+      })
+    })
+  })
 })

--- a/packages/plugin-breadcrumbs-console/src/index.ts
+++ b/packages/plugin-breadcrumbs-console/src/index.ts
@@ -32,7 +32,7 @@ function consoleBreadcrumbsPlugin(options?: { [key: string]: any }) {
               // attempt to get a useful value
               // the `metadata` object should be <string, string>, so nested
               // objects won't necessarily work here
-              typeof arg === "string" ? arg : JSON.stringify(arg))
+              serializeValue(arg, method))
         )
 
         self.addBreadcrumb(breadcrumb)
@@ -42,6 +42,19 @@ function consoleBreadcrumbsPlugin(options?: { [key: string]: any }) {
 
       ;(console as any)[method] = _console
     })
+  }
+}
+
+function serializeValue(value: any, method: string) {
+  if (typeof value === "string") {
+    return value
+  } else {
+    try {
+      return JSON.stringify(value)
+    } catch (error) {
+      console.error(`Could not serialize "console.${method}" to String.`, error)
+      return "[Value could not be serialized]"
+    }
   }
 }
 


### PR DESCRIPTION
In the plugin-breadcrumbs-console if a user tried to log an object that
was self referencing, that had a circular structure, it would throw an
error that we did not catch and caused an error for the user.

This applies the same fix as for #490: catch the error and send an
alternative value instead.

The console.error message on failure will create another breadcrumb, and
this is fine. This way users know something went wrong with the
breadcrumb.

The console.error on failure to serialize the value will not cause an
infinite loop of breadcrumbs being created. It will only add the error
message as a breadcrumb once.

Fixes #163
Based on #524
