### PR TITLE
Rename apiKey to pushApiKey in Node.js installer

### DIFF
--- a/packages/cli/src/installers/node/index.ts
+++ b/packages/cli/src/installers/node/index.ts
@@ -11,14 +11,14 @@ import { SUPPORTED_NODEJS_INTEGRATIONS } from "../../constants"
  * indendation is intentional, due to JavaScripts handling of multi-line
  * strings
  */
-const displayOutroMessage = (apiKey: string, name: string) => `
+const displayOutroMessage = (pushApiKey: string, name: string) => `
 🎉 ${chalk.greenBright(
   "Great news!"
 )} You've just installed AppSignal to your project!
 
 The next step is adding your Push API key to your project. The best way to do this is with an environment variable:
 
-${chalk.bold(`export APPSIGNAL_PUSH_API_KEY="${apiKey}"`)}
+${chalk.bold(`export APPSIGNAL_PUSH_API_KEY="${pushApiKey}"`)}
 
 If you're using a cloud provider such as Heroku etc., seperate instructions on how to add these environment variables are available in our documentation:
 
@@ -48,10 +48,10 @@ Need any further help? Feel free to ask a human at ${chalk.bold(
 export async function installNode(pkg: { [key: string]: any }) {
   const cwd = process.cwd()
 
-  const { apiKey, name } = await inquirer.prompt([
+  const { pushApiKey, name } = await inquirer.prompt([
     {
       type: "input",
-      name: "apiKey",
+      name: "pushApiKey",
       message: "What's your Push API Key?",
       validate: validateApiKey
     },
@@ -129,7 +129,7 @@ export async function installNode(pkg: { [key: string]: any }) {
         ...process.env,
         APPSIGNAL_APP_ENV: "development",
         APPSIGNAL_APP_NAME: name,
-        APPSIGNAL_PUSH_API_KEY: apiKey
+        APPSIGNAL_PUSH_API_KEY: pushApiKey
       },
       stdio: "ignore"
     }).unref()
@@ -159,16 +159,16 @@ export async function installNode(pkg: { [key: string]: any }) {
     )
   }
 
-  console.log(displayOutroMessage(apiKey, name))
+  console.log(displayOutroMessage(pushApiKey, name))
 }
 
 /**
  * Validates the answer from Inquirer.js to validate the Push API key that is
  * asked for in question one
  */
-async function validateApiKey(apiKey: string) {
+async function validateApiKey(pushApiKey: string) {
   try {
-    const validated = await validatePushApiKey({ apiKey })
+    const validated = await validatePushApiKey({ apiKey: pushApiKey })
 
     if (validated === true) {
       return validated


### PR DESCRIPTION
In PR https://github.com/appsignal/appsignal-nodejs/pull/507
on the Node.js integration we renamed `apiKey` to `pushApiKey` to make
it more consistent with the other integrations. Update the code in the
installer to match.

I've only not updated the `validatePushApiKey` function, because that
meant updating the core package too. I think it would make more sense
to remove that function from the core package and use the Node.js
package's validator instead. Now we only use the core package for this
one function and that function is not used by the core package.

[skip changeset] as users won't notice this change, it only makes it
more readable for us.
[skip review] as it's only a variable name change.
