### PR TITLE
Bump React dependency version requirement

### DIFF
--- a/packages/react/.changesets/support-react-17.md
+++ b/packages/react/.changesets/support-react-17.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Update @appsignal/react package to allow React 17 installs.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -22,7 +22,7 @@
     "@appsignal/types": "=2.1.6"
   },
   "peerDependencies": {
-    "react": "^16.8.6"
+    "react": ">= 16.8.6 < 18.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
React 17 is out. We test against it in our CI setup. Let's update the
version lock to also allow React 17. I've locked to lower than version
18, just so that we are prompted to add the React 18 build to our CI
setup.

Closes #481