### PR TITLE
Serialise objects with circular references

### DIFF
--- a/packages/plugin-breadcrumbs-console/.changesets/serialise-circular-references-in-console-arguments.md
+++ b/packages/plugin-breadcrumbs-console/.changesets/serialise-circular-references-in-console-arguments.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Serialise circular references in console arguments, omitting the cyclic value instead of throwing an error.

--- a/packages/plugin-breadcrumbs-console/src/__tests__/index.test.ts
+++ b/packages/plugin-breadcrumbs-console/src/__tests__/index.test.ts
@@ -114,12 +114,11 @@ describe("BreadcrumbsConsolePlugin", () => {
   })
 
   describe("when console function is called with a normal object argument", () => {
-    it("adds breadcrumb without argument", () => {
+    it("adds breadcrumb with argument", () => {
       const obj = { value1: "abc", nested: { value2: "def" } }
       console.log(obj)
 
       expect(logMock).toHaveBeenCalledWith(obj)
-      expect(errorMock).not.toHaveBeenCalled()
       expect(addBreadcrumb).toHaveBeenCalledWith({
         action: "Console logged a value",
         category: "console.log",
@@ -131,22 +130,21 @@ describe("BreadcrumbsConsolePlugin", () => {
   })
 
   describe("when console function is called with a circular argument", () => {
-    it("adds breadcrumb without argument", () => {
-      const obj: { [key: string]: string | object } = { value1: "abc" }
+    it("adds breadcrumb with cyclic values replaced", () => {
+      const obj: { [key: string]: any } = { value1: "abc", nested: {} }
       obj.obj = obj
+      obj.nested["inside"] = obj.nested
       console.log(obj)
 
       expect(logMock).toHaveBeenCalledWith(obj)
-      expect(errorMock).toHaveBeenCalledTimes(1)
-      expect(errorMock).toHaveBeenCalledWith(
-        'Could not serialize "console.log" to String.',
-        expect.any(Error)
-      )
       expect(addBreadcrumb).toHaveBeenCalledWith({
         action: "Console logged a value",
         category: "console.log",
         metadata: {
-          argument0: "[Value could not be serialized]"
+          argument0:
+            `{"value1":"abc",` +
+            `"nested":{"inside":"[cyclic value: nested]"},` +
+            `"obj":"[cyclic value: root object]"}`
         }
       })
     })

--- a/packages/plugin-breadcrumbs-console/src/index.ts
+++ b/packages/plugin-breadcrumbs-console/src/index.ts
@@ -46,15 +46,31 @@ function consoleBreadcrumbsPlugin(options?: { [key: string]: any }) {
 }
 
 function serializeValue(value: any, method: string) {
-  if (typeof value === "string") {
-    return value
-  } else {
-    try {
-      return JSON.stringify(value)
-    } catch (error) {
-      console.error(`Could not serialize "console.${method}" to String.`, error)
-      return "[Value could not be serialized]"
+  switch (typeof value) {
+    case "string":
+      return value
+    case "undefined":
+      return "undefined"
+    default:
+      return JSON.stringify(value, circularReplacer())
+  }
+}
+
+function circularReplacer() {
+  const seenValue: any[] = []
+  const seenKey: string[] = []
+  return (key: string, value: any) => {
+    if (typeof value === "object" && value !== null) {
+      const i = seenValue.indexOf(value)
+      if (i !== -1) {
+        return `[cyclic value: ${seenKey[i] || "root object"}]`
+      } else {
+        seenValue.push(value)
+        seenKey.push(key)
+      }
     }
+
+    return value
   }
 }
 


### PR DESCRIPTION
This commit changes the behaviour of the console breadcrumbs plugin so that it handles circular references, omitting the cyclic value from the serialised object, instead of throwing an error.

Before, an object with a circular reference passed to console.log would fail to be serialised, resulting in a not very useful breadcrumb, and triggering a second error to be emitted about the failure to serialise, which polluted the console and the breadcrumbs output.

After this change, circular references are serialised by replacing the cyclic value with a string of the form `[cyclic value: $key]`, where `$key` is the name of the key under which the value was previously encountered, or "root object" if the root object is the referenced value.

Note that this can also replace values that don't form cycles, but that are merely referenced several times across the JSON. Other solutions to this problem, such as [Crockford's cycle.js][cycle], also behave in this manner.

The `circularReplacer` function is based on [an MDN snippet][mdn] about circular references in JSON serialization.

[cycle]: https://github.com/douglascrockford/JSON-js/blob/8e8b0407e475e35942f7e9461dab81929fcc7321/cycle.js#L29-L32
[mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cyclic_object_value#circular_references

Fixes appsignal/support#163, probably.