### PR TITLE
Check if thrown object is error in ErrorBoundary

### DIFF
--- a/packages/core/.changesets/add-internal-utility-to-check-if-object-is-an-error-.md
+++ b/packages/core/.changesets/add-internal-utility-to-check-if-object-is-an-error-.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add internal `isError` utility function to check if an object is an error.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,7 @@
 // Utils
 export * from "./utils/functional"
 export * from "./utils/hashmap"
-export * from "./utils/stacktrace"
+export * from "./utils/error"
 export * from "./utils/url"
 export * from "./utils/async"
 export * from "./utils/environment"

--- a/packages/core/src/utils/__tests__/error.test.ts
+++ b/packages/core/src/utils/__tests__/error.test.ts
@@ -1,0 +1,15 @@
+import { isError } from "../error"
+
+describe("isError", () => {
+  it("with Error returns true", () => {
+    expect(isError(new Error())).toBe(true)
+  })
+
+  it("with Event returns false", () => {
+    expect(isError(new Event("message") as any)).toBe(false)
+  })
+
+  it("with object returns false", () => {
+    expect(isError({} as any)).toBe(false)
+  })
+})

--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -1,4 +1,20 @@
 /**
+ * Check if the given object is an error-like object.
+ *
+ * @param   {Error | T}     error      An `Error` object or an error-like object
+ *
+ * @return  {boolean}
+ */
+export function isError<T extends Error>(error: Error | T): boolean {
+  return (
+    typeof (error as any).message !== "undefined" &&
+    (typeof (error as any).stacktrace !== "undefined" ||
+      typeof (error as any)["opera#sourceloc"] !== "undefined" ||
+      typeof (error as any).stack !== "undefined")
+  )
+}
+
+/**
  * Get backtrace from an `Error` object, or an error-like object
  *
  * @param   {Error | T}     error      An `Error` object or an error-like object

--- a/packages/react/.changesets/check-if-thrown-object-is-an-error.md
+++ b/packages/react/.changesets/check-if-thrown-object-is-an-error.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+In the React ErrorBoundary, check if the thrown object is an error. This prevents an error being thrown when the previously thrown error was not an error. Scenarios like `throw new Event("my event")` are now ignored.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,7 +19,8 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@appsignal/types": "=2.1.6"
+    "@appsignal/types": "=2.1.6",
+    "@appsignal/core": "=1.1.14"
   },
   "peerDependencies": {
     "react": ">= 16.8.6 < 18.0.0"

--- a/packages/react/src/ErrorBoundary.tsx
+++ b/packages/react/src/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { Props, State } from "./types/component"
+import { isError } from "@appsignal/core"
 
 export class ErrorBoundary extends React.Component<Props, State> {
   state = { error: undefined }
@@ -9,10 +10,12 @@ export class ErrorBoundary extends React.Component<Props, State> {
   }
 
   static getDerivedStateFromError(error: Error): State {
-    return { error }
+    return isError(error) ? { error } : {}
   }
 
   public componentDidCatch(error: Error): void {
+    if (!isError(error)) return
+
     const { instance: appsignal, action, tags = {} } = this.props
     const span = appsignal.createSpan()
 

--- a/packages/react/src/__tests__/ErrorBoundary.test.tsx
+++ b/packages/react/src/__tests__/ErrorBoundary.test.tsx
@@ -10,15 +10,23 @@ describe("<ErrorBoundary />", () => {
     return <div></div>
   }
 
-  const mock: any = {
-    setAction: jest.fn(() => mock),
-    setError: jest.fn(() => mock),
-    setTags: jest.fn(() => mock)
+  const BrokenEvent = () => {
+    throw new Event("From component")
+    return <div></div>
   }
 
-  const SpanMock = jest.fn().mockImplementation(() => mock)
+  let mock: any
+
+  let SpanMock: any
 
   beforeEach(() => {
+    jest.resetAllMocks()
+    mock = {
+      setAction: jest.fn(() => mock),
+      setError: jest.fn(() => mock),
+      setTags: jest.fn(() => mock)
+    }
+    SpanMock = jest.fn().mockImplementation(() => mock)
     instance = {
       createSpan: () => new SpanMock(),
       send: jest.fn()
@@ -41,6 +49,22 @@ describe("<ErrorBoundary />", () => {
     expect(mock.setError).toBeCalled()
 
     expect(instance.send).toBeCalled()
+  })
+
+  it("ignores non-Error objects being thrown", () => {
+    expect(() => {
+      render(
+        <ErrorBoundary instance={instance} fallback={() => <div>Fallback</div>}>
+          <BrokenEvent />
+        </ErrorBoundary>
+      )
+    }).toThrow(Event)
+
+    expect(mock.setAction).not.toBeCalled()
+    expect(mock.setTags).not.toBeCalled()
+    expect(mock.setError).not.toBeCalled()
+
+    expect(instance.send).not.toBeCalled()
   })
 
   it("modifies the action if provided as a prop", () => {


### PR DESCRIPTION
In JavaScript an app can throw any object, not just errors. For example:
`throw new Event("my event")`.

Before we track those thrown objects as errors in AppSignal, make sure
the object is actually an error. I've added the `isError` function for
that in the core library to make this reusable in the future. This
function is then used in the React ErrorBoundary.

For the `isError` tests I had to cast the arguments to `is any`, because
otherwise TypeScript would complain about giving an incompatible type.
Something which the ErrorBoundary itself has no issues with
apparently.

Fixes #532