### PR TITLE
Serialise objects with circular references in window errors plugin

### DIFF
--- a/packages/plugin-window-events/.changesets/serialise-circular-references-in-window-errors.md
+++ b/packages/plugin-window-events/.changesets/serialise-circular-references-in-window-errors.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Serialise circular references in window errors, omitting the cyclic value instead of throwing an error.

--- a/packages/plugin-window-events/src/index.ts
+++ b/packages/plugin-window-events/src/index.ts
@@ -101,11 +101,24 @@ function windowEventsPlugin(options?: { [key: string]: any }) {
       return error.reason
     }
 
-    try {
-      return JSON.stringify(error.reason)
-    } catch (e) {
-      console.error("Could not serialize error reason to String.", e)
-      return undefined
+    return JSON.stringify(error.reason, circularReplacer())
+  }
+
+  function circularReplacer() {
+    const seenValue: any[] = []
+    const seenKey: string[] = []
+    return (key: string, value: any) => {
+      if (typeof value === "object" && value !== null) {
+        const i = seenValue.indexOf(value)
+        if (i !== -1) {
+          return `[cyclic value: ${seenKey[i] || "root object"}]`
+        } else {
+          seenValue.push(value)
+          seenKey.push(key)
+        }
+      }
+
+      return value
     }
   }
 }


### PR DESCRIPTION
This commit changes the behaviour of the window events plugin so that it handles circular references, omitting the cyclic value from the serialised object, instead of throwing an error.

This commit applies the changes to the console breadcrumbs plugin in [#534][pr] (commit [af829d6][commit]) to the window events plugin. More details about the changes can be found there.

[pr]: https://github.com/appsignal/appsignal-javascript/pull/534
[commit]: https://github.com/appsignal/appsignal-javascript/commit/af829d6b5b6b1a4e1dae528e35f3648421b31efa