### PR TITLE
Fix dependency installation in CI build

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -57,7 +57,7 @@ blocks:
       - cache restore
       - cache store
       - mono bootstrap
-      - npm run lint
+      - yarn lint
     - name: Git Lint (Lintje)
       commands:
       - script/lint_git
@@ -91,17 +91,17 @@ blocks:
       - cache restore $_PACKAGES_CACHE-packages-$SEMAPHORE_GIT_SHA-v$NODE_VERSION
       - mono bootstrap --ci
     jobs:
-    - name: "@appsignal/angular - angular@latest"
+    - name: "@appsignal/angular - angular@12.2.15"
       commands:
-      - "(cd packages/angular && npm install @angular/core@latest --save-dev)"
+      - yarn add @angular/core@12.2.15 --dev --ignore-workspace-root-check
       - mono test --package=@appsignal/angular
     - name: "@appsignal/angular - angular@8.2.14"
       commands:
-      - "(cd packages/angular && npm install @angular/core@8.2.14 --save-dev)"
+      - yarn add @angular/core@8.2.14 --dev --ignore-workspace-root-check
       - mono test --package=@appsignal/angular
     - name: "@appsignal/angular - angular@8.1.3"
       commands:
-      - "(cd packages/angular && npm install @angular/core@8.1.3 --save-dev)"
+      - yarn add @angular/core@8.1.3 --dev --ignore-workspace-root-check
       - mono test --package=@appsignal/angular
     - name: "@appsignal/core - core"
       commands:
@@ -117,37 +117,37 @@ blocks:
       - mono test --package=@appsignal/plugin-window-events
     - name: "@appsignal/preact - preact@latest"
       commands:
-      - "(cd packages/preact && npm install preact@latest --save-dev)"
+      - yarn add preact@latest --dev --ignore-workspace-root-check
       - mono test --package=@appsignal/preact
     - name: "@appsignal/preact - preact@10.5.15"
       commands:
-      - "(cd packages/preact && npm install preact@10.5.15 --save-dev)"
+      - yarn add preact@10.5.15 --dev --ignore-workspace-root-check
       - mono test --package=@appsignal/preact
     - name: "@appsignal/preact - preact@10.4.8"
       commands:
-      - "(cd packages/preact && npm install preact@10.4.8 --save-dev)"
+      - yarn add preact@10.4.8 --dev --ignore-workspace-root-check
       - mono test --package=@appsignal/preact
     - name: "@appsignal/react - react@latest"
       commands:
-      - "(cd packages/react && npm install react@latest --save-dev)"
+      - yarn add react@latest --dev --ignore-workspace-root-check
       - mono test --package=@appsignal/react
     - name: "@appsignal/react - react@17.0.2"
       commands:
-      - "(cd packages/react && npm install react@17.0.2 --save-dev)"
+      - yarn add react@17.0.2 --dev --ignore-workspace-root-check
       - mono test --package=@appsignal/react
     - name: "@appsignal/react - react@16.14.0"
       commands:
-      - "(cd packages/react && npm install react@16.14.0 --save-dev)"
+      - yarn add react@16.14.0 --dev --ignore-workspace-root-check
       - mono test --package=@appsignal/react
     - name: "@appsignal/vue - vue@latest"
       commands:
-      - "(cd packages/vue && npm install vue@latest --save-dev)"
+      - yarn add vue@latest --dev --ignore-workspace-root-check
       - mono test --package=@appsignal/vue
     - name: "@appsignal/vue - vue@3.2.20"
       commands:
-      - "(cd packages/vue && npm install vue@3.2.20 --save-dev)"
+      - yarn add vue@3.2.20 --dev --ignore-workspace-root-check
       - mono test --package=@appsignal/vue
     - name: "@appsignal/vue - vue@2.6.14"
       commands:
-      - "(cd packages/vue && npm install vue@2.6.14 --save-dev)"
+      - yarn add vue@2.6.14 --dev --ignore-workspace-root-check
       - mono test --package=@appsignal/vue

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -95,13 +95,9 @@ blocks:
       commands:
       - yarn add @angular/core@12.2.15 --dev --ignore-workspace-root-check
       - mono test --package=@appsignal/angular
-    - name: "@appsignal/angular - angular@8.2.14"
+    - name: "@appsignal/angular - angular@11.2.14"
       commands:
-      - yarn add @angular/core@8.2.14 --dev --ignore-workspace-root-check
-      - mono test --package=@appsignal/angular
-    - name: "@appsignal/angular - angular@8.1.3"
-      commands:
-      - yarn add @angular/core@8.1.3 --dev --ignore-workspace-root-check
+      - yarn add @angular/core@11.2.14 --dev --ignore-workspace-root-check
       - mono test --package=@appsignal/angular
     - name: "@appsignal/core - core"
       commands:

--- a/Rakefile
+++ b/Rakefile
@@ -55,7 +55,7 @@ namespace :build_matrix do
                 "#{name}@#{version}"
               end.join(" ")
               [
-                "(cd #{package["path"]} && npm install #{packages} --save-dev)",
+                "yarn add #{packages} --dev --ignore-workspace-root-check",
                 "script/install_test_example_packages " \
                   "#{File.basename package["path"]} #{packages}"
               ]

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -67,12 +67,9 @@ matrix:
         - name: "angular@12.2.15"
           packages:
             "@angular/core": "12.2.15"
-        - name: "angular@8.2.14"
+        - name: "angular@11.2.14"
           packages:
-            "@angular/core": "8.2.14"
-        - name: "angular@8.1.3"
-          packages:
-            "@angular/core": "8.1.3"
+            "@angular/core": "11.2.14"
     - package: "@appsignal/cli"
       path: "packages/cli"
       variations:

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -54,7 +54,7 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
               - cache restore
               - cache store
               - mono bootstrap
-              - npm run lint
+              - yarn lint
           - name: Git Lint (Lintje)
             commands:
               - script/lint_git
@@ -64,9 +64,9 @@ matrix:
     - package: "@appsignal/angular"
       path: "packages/angular"
       variations:
-        - name: "angular@latest"
+        - name: "angular@12.2.15"
           packages:
-            "@angular/core": "latest"
+            "@angular/core": "12.2.15"
         - name: "angular@8.2.14"
           packages:
             "@angular/core": "8.2.14"

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "dependencies": {},
   "devDependencies": {
+    "@angular/core": "^12.2.15",
     "@appsignal/types": "^2.1.5",
-    "@angular/core": "^11.0.5",
     "@testing-library/preact": "^2.0.1",
     "@testing-library/react": "^11.1.2",
     "@types/inquirer": "^7.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,12 @@
 # yarn lockfile v1
 
 
-"@angular/core@^11.0.5":
-  version "11.0.5"
-  resolved "https://registry.yarnpkg.com/@angular/core/-/core-11.0.5.tgz#b8c448c3cd4f6dae7327cc1ba4ee2aa29c8dbc26"
-  integrity sha512-XAXWQi7R3ucZXQwx9QK5jSKJeQyRJ53u2dQDpr7R5stzeCy1a5hrNOkZLg9zOTTPcth/6+FrOrRZP9SMdxtw3w==
+"@angular/core@^12.2.15":
+  version "12.2.15"
+  resolved "https://registry.yarnpkg.com/@angular/core/-/core-12.2.15.tgz#e1b0b703a68dc9d626d43af082169299433f913b"
+  integrity sha512-67SS/eNN3kMvh5WSoRz5OPJYuh/kb9lFXS+iOgnDdPyI+HKdVlBrO4iW2EPCcE0gFrlVrbao8JrJfGtUz4Hs/w==
   dependencies:
-    tslib "^2.0.0"
+    tslib "^2.2.0"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4":
   version "7.10.4"
@@ -4713,12 +4713,7 @@ tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
-  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
-
-tslib@^2.3.0:
+tslib@^2.2.0, tslib@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==


### PR DESCRIPTION
The CI build did not use the local versions of packages if a specific
dependency version was installed by the CI setup. This because it called
`npm install dependency@version` in the package's directory, rather than
the root. We normally keep all the test dependency packages in the root
directory's `package.json`.

The `npm install` command was also wrong. This repo uses `yarn`, so I've
updated that.

There is a problem with Angular 13. It's documented in issue #539. For
now I've added the previous major version Angular 12 to the build
instead.

[skip changeset]