### PR TITLE
Update Angular versions in CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -95,13 +95,9 @@ blocks:
       commands:
       - yarn add @angular/core@12.2.15 --dev --ignore-workspace-root-check
       - mono test --package=@appsignal/angular
-    - name: "@appsignal/angular - angular@8.2.14"
+    - name: "@appsignal/angular - angular@11.2.14"
       commands:
-      - yarn add @angular/core@8.2.14 --dev --ignore-workspace-root-check
-      - mono test --package=@appsignal/angular
-    - name: "@appsignal/angular - angular@8.1.3"
-      commands:
-      - yarn add @angular/core@8.1.3 --dev --ignore-workspace-root-check
+      - yarn add @angular/core@11.2.14 --dev --ignore-workspace-root-check
       - mono test --package=@appsignal/angular
     - name: "@appsignal/core - core"
       commands:

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -67,12 +67,9 @@ matrix:
         - name: "angular@12.2.15"
           packages:
             "@angular/core": "12.2.15"
-        - name: "angular@8.2.14"
+        - name: "angular@11.2.14"
           packages:
-            "@angular/core": "8.2.14"
-        - name: "angular@8.1.3"
-          packages:
-            "@angular/core": "8.1.3"
+            "@angular/core": "11.2.14"
     - package: "@appsignal/cli"
       path: "packages/cli"
       variations:


### PR DESCRIPTION
We now test against version 8, which is no longer supported. Update the
versions we test against to the maintained versions of Angular:
https://angular.io/guide/releases#support-policy-and-schedule

Fixes #537

[skip changeset]
[skip review]