### PR TITLE
Check if thrown object is error in ErrorBoundary

### DIFF
--- a/packages/preact/.changesets/check-if-thrown-object-is-an-error.md
+++ b/packages/preact/.changesets/check-if-thrown-object-is-an-error.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+In the Preact ErrorBoundary, check if the thrown object is an error. This prevents an error being thrown when the previously thrown error was not an error. Scenarios like `throw new Event("my event")` are now ignored.

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -19,7 +19,8 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@appsignal/types": "=2.1.6"
+    "@appsignal/types": "=2.1.6",
+    "@appsignal/core": "=1.1.15"
   },
   "peerDependencies": {
     "preact": "^10.0.0"

--- a/packages/preact/src/ErrorBoundary.tsx
+++ b/packages/preact/src/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Component } from "preact"
 import { Props, State } from "./types/component"
+import { isError } from "@appsignal/core"
 
 export class ErrorBoundary extends Component<Props, State> {
   state = { error: undefined }
@@ -9,6 +10,8 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   public componentDidCatch(error: Error, info: any): void {
+    if (!isError(error)) return
+
     const { instance: appsignal, action, tags } = this.props
     const { name, message, stack } = error
     const span = appsignal.createSpan()

--- a/packages/preact/src/__tests__/ErrorBoundary.test.tsx
+++ b/packages/preact/src/__tests__/ErrorBoundary.test.tsx
@@ -10,15 +10,22 @@ describe("<ErrorBoundary />", () => {
     return <div></div>
   }
 
-  const mock: any = {
-    setAction: jest.fn(() => mock),
-    setError: jest.fn(() => mock),
-    setTags: jest.fn(() => mock)
+  const BrokenEvent = () => {
+    throw new Event("My event")
+    return <div></div>
   }
 
-  const SpanMock = jest.fn().mockImplementation(() => mock)
+  let mock: any
+  let SpanMock: any
 
   beforeEach(() => {
+    jest.resetAllMocks()
+    mock = {
+      setAction: jest.fn(() => mock),
+      setError: jest.fn(() => mock),
+      setTags: jest.fn(() => mock)
+    }
+    SpanMock = jest.fn().mockImplementation(() => mock)
     instance = {
       createSpan: () => new SpanMock(),
       send: jest.fn()
@@ -41,6 +48,22 @@ describe("<ErrorBoundary />", () => {
     expect(mock.setError).toBeCalled()
 
     expect(instance.send).toBeCalled()
+  })
+
+  it("ignores non-Error objects being thrown", () => {
+    expect(() => {
+      render(
+        <ErrorBoundary instance={instance}>
+          <BrokenEvent />
+        </ErrorBoundary>
+      )
+    }).toThrow()
+
+    expect(mock.setAction).not.toBeCalled()
+    expect(mock.setTags).not.toBeCalled()
+    expect(mock.setError).not.toBeCalled()
+
+    expect(instance.send).not.toBeCalled()
   })
 
   it("modifies the action if provided as a prop", () => {


### PR DESCRIPTION
In JavaScript an app can throw any object, not just errors. For example:
`throw new Event("my event")`.

Before we track those thrown objects as errors in AppSignal, make sure
the object is actually an error. I've added the `isError` function for
that in the core library to make this reusable in the future. This
function is then used in the React and Preact ErrorBoundary.

Fixes #532