### PR TITLE
Resolve Ember Global deprecation

### DIFF
--- a/packages/ember/src/index.ts
+++ b/packages/ember/src/index.ts
@@ -1,8 +1,9 @@
 import type { JSClient, JSSpan } from "@appsignal/types"
+import Ember from 'ember';
 
 export function installErrorHandler(
   appsignal: JSClient,
-  Ember = (window as any).Ember
+  Ember = Ember
 ) {
   const prevHandler = Ember.onerror
 


### PR DESCRIPTION
> DEPRECATION: Usage of the Ember Global is deprecated. You should import the Ember module or the specific API instead. [deprecation id: ember-global] See https://deprecations.emberjs.com/v3.x/#toc_ember-global for more details.