### PR TITLE
Update package.json metadata

### DIFF
--- a/packages/angular/.changesets/update-package-json-metadata.md
+++ b/packages/angular/.changesets/update-package-json-metadata.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Update package metadata to be more up-to-date and to specify the package location in the mono repository.

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -3,7 +3,11 @@
   "version": "1.0.14",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "repository": "git@github.com:appsignal/appsignal-javascript.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/appsignal/appsignal-javascript.git",
+    "directory": "packages/angular"
+  },
   "license": "MIT",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -4,7 +4,6 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "repository": "git@github.com:appsignal/appsignal-javascript.git",
-  "author": "Adam Yeats <adam@appsignal.com>",
   "license": "MIT",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm",

--- a/packages/cli/.changesets/update-package-json-metadata.md
+++ b/packages/cli/.changesets/update-package-json-metadata.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Update package metadata to be more up-to-date and to specify the package location in the mono repository.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,7 +3,6 @@
   "version": "1.1.14",
   "main": "./dist/index",
   "repository": "git@github.com:appsignal/appsignal-javascript.git",
-  "author": "Adam Yeats <adam@appsignal.com>",
   "license": "MIT",
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,7 +2,11 @@
   "name": "@appsignal/cli",
   "version": "1.1.14",
   "main": "./dist/index",
-  "repository": "git@github.com:appsignal/appsignal-javascript.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/appsignal/appsignal-javascript.git",
+    "directory": "packages/cli"
+  },
   "license": "MIT",
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/core/.changesets/update-package-json-metadata.md
+++ b/packages/core/.changesets/update-package-json-metadata.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Update package metadata to be more up-to-date and to specify the package location in the mono repository.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,6 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "repository": "git@github.com:appsignal/appsignal-javascript.git",
-  "author": "Adam Yeats <adam@appsignal.com>",
   "license": "MIT",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,11 @@
   "version": "1.1.16",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "repository": "git@github.com:appsignal/appsignal-javascript.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/appsignal/appsignal-javascript.git",
+    "directory": "packages/core"
+  },
   "license": "MIT",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm",

--- a/packages/ember/.changesets/update-package-json-metadata.md
+++ b/packages/ember/.changesets/update-package-json-metadata.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Update package metadata to be more up-to-date and to specify the package location in the mono repository.

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -3,7 +3,11 @@
   "version": "1.0.14",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "repository": "git@github.com:appsignal/appsignal-javascript.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/appsignal/appsignal-javascript.git",
+    "directory": "packages/ember"
+  },
   "license": "MIT",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm",

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -4,7 +4,6 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "repository": "git@github.com:appsignal/appsignal-javascript.git",
-  "author": "Adam Yeats <adam@appsignal.com>",
   "license": "MIT",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm",

--- a/packages/javascript/.changesets/update-package-json-metadata.md
+++ b/packages/javascript/.changesets/update-package-json-metadata.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Update package metadata to be more up-to-date and to specify the package location in the mono repository.

--- a/packages/javascript/package.json
+++ b/packages/javascript/package.json
@@ -3,7 +3,11 @@
   "version": "1.3.21",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "repository": "git@github.com:appsignal/appsignal-javascript.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/appsignal/appsignal-javascript.git",
+    "directory": "packages/javascript"
+  },
   "license": "MIT",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm",

--- a/packages/javascript/package.json
+++ b/packages/javascript/package.json
@@ -4,7 +4,6 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "repository": "git@github.com:appsignal/appsignal-javascript.git",
-  "author": "Adam Yeats <adam@appsignal.com>",
   "license": "MIT",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm",

--- a/packages/plugin-breadcrumbs-console/.changesets/update-package-json-metadata.md
+++ b/packages/plugin-breadcrumbs-console/.changesets/update-package-json-metadata.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Update package metadata to be more up-to-date and to specify the package location in the mono repository.

--- a/packages/plugin-breadcrumbs-console/package.json
+++ b/packages/plugin-breadcrumbs-console/package.json
@@ -4,7 +4,6 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "repository": "git@github.com:appsignal/appsignal-javascript.git",
-  "author": "Adam Yeats <adam@appsignal.com>",
   "license": "MIT",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm",

--- a/packages/plugin-breadcrumbs-console/package.json
+++ b/packages/plugin-breadcrumbs-console/package.json
@@ -3,7 +3,11 @@
   "version": "1.1.22",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "repository": "git@github.com:appsignal/appsignal-javascript.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/appsignal/appsignal-javascript.git",
+    "directory": "packages/plugin-breadcrumbs-console"
+  },
   "license": "MIT",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm",

--- a/packages/plugin-breadcrumbs-network/.changesets/update-package-json-metadata.md
+++ b/packages/plugin-breadcrumbs-network/.changesets/update-package-json-metadata.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Update package metadata to be more up-to-date and to specify the package location in the mono repository.

--- a/packages/plugin-breadcrumbs-network/package.json
+++ b/packages/plugin-breadcrumbs-network/package.json
@@ -3,7 +3,11 @@
   "version": "1.1.20",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "repository": "git@github.com:appsignal/appsignal-javascript.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/appsignal/appsignal-javascript.git",
+    "directory": "packages/plugin-breadcrumbs-network"
+  },
   "license": "MIT",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm",

--- a/packages/plugin-breadcrumbs-network/package.json
+++ b/packages/plugin-breadcrumbs-network/package.json
@@ -4,7 +4,6 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "repository": "git@github.com:appsignal/appsignal-javascript.git",
-  "author": "Adam Yeats <adam@appsignal.com>",
   "license": "MIT",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm",

--- a/packages/plugin-path-decorator/.changesets/update-package-json-metadata.md
+++ b/packages/plugin-path-decorator/.changesets/update-package-json-metadata.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Update package metadata to be more up-to-date and to specify the package location in the mono repository.

--- a/packages/plugin-path-decorator/package.json
+++ b/packages/plugin-path-decorator/package.json
@@ -3,7 +3,11 @@
   "version": "1.0.14",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "repository": "git@github.com:appsignal/appsignal-javascript.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/appsignal/appsignal-javascript.git",
+    "directory": "packages/plugin-path-decorator"
+  },
   "license": "MIT",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm",

--- a/packages/plugin-path-decorator/package.json
+++ b/packages/plugin-path-decorator/package.json
@@ -4,7 +4,6 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "repository": "git@github.com:appsignal/appsignal-javascript.git",
-  "author": "Adam Yeats <adam@appsignal.com>",
   "license": "MIT",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm",

--- a/packages/plugin-window-events/.changesets/update-package-json-metadata.md
+++ b/packages/plugin-window-events/.changesets/update-package-json-metadata.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Update package metadata to be more up-to-date and to specify the package location in the mono repository.

--- a/packages/plugin-window-events/package.json
+++ b/packages/plugin-window-events/package.json
@@ -3,7 +3,11 @@
   "version": "1.0.16",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "repository": "git@github.com:appsignal/appsignal-javascript.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/appsignal/appsignal-javascript.git",
+    "directory": "packages/plugin-window-events"
+  },
   "license": "MIT",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm",

--- a/packages/plugin-window-events/package.json
+++ b/packages/plugin-window-events/package.json
@@ -4,7 +4,6 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "repository": "git@github.com:appsignal/appsignal-javascript.git",
-  "author": "Adam Yeats <adam@appsignal.com>",
   "license": "MIT",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm",

--- a/packages/preact/.changesets/update-package-json-metadata.md
+++ b/packages/preact/.changesets/update-package-json-metadata.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Update package metadata to be more up-to-date and to specify the package location in the mono repository.

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -3,7 +3,11 @@
   "version": "1.0.16",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "repository": "git@github.com:appsignal/appsignal-javascript.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/appsignal/appsignal-javascript.git",
+    "directory": "packages/preact"
+  },
   "license": "MIT",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm",

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -4,7 +4,6 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "repository": "git@github.com:appsignal/appsignal-javascript.git",
-  "author": "Adam Yeats <adam@appsignal.com>",
   "license": "MIT",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm",

--- a/packages/react/.changesets/update-package-json-metadata.md
+++ b/packages/react/.changesets/update-package-json-metadata.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Update package metadata to be more up-to-date and to specify the package location in the mono repository.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -3,7 +3,11 @@
   "version": "1.0.17",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "repository": "git@github.com:appsignal/appsignal-javascript.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/appsignal/appsignal-javascript.git",
+    "directory": "packages/react"
+  },
   "license": "MIT",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,7 +4,6 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "repository": "git@github.com:appsignal/appsignal-javascript.git",
-  "author": "Adam Yeats <adam@appsignal.com>",
   "license": "MIT",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm",

--- a/packages/stimulus/.changesets/update-package-json-metadata.md
+++ b/packages/stimulus/.changesets/update-package-json-metadata.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Update package metadata to be more up-to-date and to specify the package location in the mono repository.

--- a/packages/stimulus/package.json
+++ b/packages/stimulus/package.json
@@ -3,7 +3,11 @@
   "version": "1.0.14",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "repository": "git@github.com:appsignal/appsignal-javascript.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/appsignal/appsignal-javascript.git",
+    "directory": "packages/stimulus"
+  },
   "license": "MIT",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm",

--- a/packages/stimulus/package.json
+++ b/packages/stimulus/package.json
@@ -4,7 +4,6 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "repository": "git@github.com:appsignal/appsignal-javascript.git",
-  "author": "Adam Yeats <adam@appsignal.com>",
   "license": "MIT",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm",

--- a/packages/types/.changesets/update-package-json-metadata.md
+++ b/packages/types/.changesets/update-package-json-metadata.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Update package metadata to be more up-to-date and to specify the package location in the mono repository.

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -5,7 +5,6 @@
   "module": "dist/esm/index.js",
   "types": "dist/cjs/index",
   "repository": "git@github.com:appsignal/appsignal-javascript.git",
-  "author": "Adam Yeats <adam@appsignal.com>",
   "license": "MIT",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -4,7 +4,11 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/cjs/index",
-  "repository": "git@github.com:appsignal/appsignal-javascript.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/appsignal/appsignal-javascript.git",
+    "directory": "packages/types"
+  },
   "license": "MIT",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm",

--- a/packages/vue/.changesets/update-package-json-metadata.md
+++ b/packages/vue/.changesets/update-package-json-metadata.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Update package metadata to be more up-to-date and to specify the package location in the mono repository.

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -3,7 +3,11 @@
   "version": "1.1.1",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "repository": "git@github.com:appsignal/appsignal-javascript.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/appsignal/appsignal-javascript.git",
+    "directory": "packages/vue"
+  },
   "license": "MIT",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -4,7 +4,6 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "repository": "git@github.com:appsignal/appsignal-javascript.git",
-  "author": "Adam Yeats <adam@appsignal.com>",
   "license": "MIT",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm",

--- a/packages/webpack/.changesets/update-package-json-metadata.md
+++ b/packages/webpack/.changesets/update-package-json-metadata.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Update package metadata to be more up-to-date and to specify the package location in the mono repository.

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -4,7 +4,6 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "repository": "git@github.com:appsignal/appsignal-javascript.git",
-  "author": "Adam Yeats <adam@appsignal.com>",
   "license": "MIT",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -3,7 +3,11 @@
   "version": "1.1.5",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "repository": "git@github.com:appsignal/appsignal-javascript.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/appsignal/appsignal-javascript.git",
+    "directory": "packages/webpack"
+  },
   "license": "MIT",
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm",


### PR DESCRIPTION
## Remove Adam as package author

Adam no longer works as AppSignal and doesn't work on these packages
anymore. To prevent anyone from trying to reach out to him about these
packages, on his AppSignal email address that no longer exists, remove
him as the author.

We can consider adding more people as contributors in the `contributors`
field in `package.json`.

We also currently do no list any author or contributors in the Node.js
integration packages.

[skip changeset]

## Update package.json to link to mono repo paths

Following the package.json definition, we can specify where in the
repository the package is located. This will make commands like `npm
repo @appsignal/core` link to the sub directory directly. And hopefully
the repository will be listed correctly on npmjs.org with this change.

No examples in the reference linked below showed the
`git@github.com:org/repo.git` format, so I've used the `https` format as
shown there.

We can also look at configuring things like the homepage, contributors
list and other useful metadata if this works.

Because I've updated all `package.json` files, all packages have a
changeset for it.

https://docs.npmjs.com/cli/v8/configuring-npm/package-json#repository
