### PR TITLE
Check if the correct package version is installed

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -93,11 +93,11 @@ blocks:
     jobs:
     - name: "@appsignal/angular - angular@12.2.15"
       commands:
-      - yarn add @angular/core@12.2.15 --dev --ignore-workspace-root-check
+      - script/install_packages @angular/core@12.2.15
       - mono test --package=@appsignal/angular
     - name: "@appsignal/angular - angular@11.2.14"
       commands:
-      - yarn add @angular/core@11.2.14 --dev --ignore-workspace-root-check
+      - script/install_packages @angular/core@11.2.14
       - mono test --package=@appsignal/angular
     - name: "@appsignal/core - core"
       commands:
@@ -113,37 +113,37 @@ blocks:
       - mono test --package=@appsignal/plugin-window-events
     - name: "@appsignal/preact - preact@latest"
       commands:
-      - yarn add preact@latest --dev --ignore-workspace-root-check
+      - script/install_packages preact@latest
       - mono test --package=@appsignal/preact
     - name: "@appsignal/preact - preact@10.5.15"
       commands:
-      - yarn add preact@10.5.15 --dev --ignore-workspace-root-check
+      - script/install_packages preact@10.5.15
       - mono test --package=@appsignal/preact
     - name: "@appsignal/preact - preact@10.4.8"
       commands:
-      - yarn add preact@10.4.8 --dev --ignore-workspace-root-check
+      - script/install_packages preact@10.4.8
       - mono test --package=@appsignal/preact
     - name: "@appsignal/react - react@latest"
       commands:
-      - yarn add react@latest --dev --ignore-workspace-root-check
+      - script/install_packages react@latest
       - mono test --package=@appsignal/react
     - name: "@appsignal/react - react@17.0.2"
       commands:
-      - yarn add react@17.0.2 --dev --ignore-workspace-root-check
+      - script/install_packages react@17.0.2
       - mono test --package=@appsignal/react
     - name: "@appsignal/react - react@16.14.0"
       commands:
-      - yarn add react@16.14.0 --dev --ignore-workspace-root-check
+      - script/install_packages react@16.14.0
       - mono test --package=@appsignal/react
     - name: "@appsignal/vue - vue@latest"
       commands:
-      - yarn add vue@latest --dev --ignore-workspace-root-check
+      - script/install_packages vue@latest
       - mono test --package=@appsignal/vue
     - name: "@appsignal/vue - vue@3.2.20"
       commands:
-      - yarn add vue@3.2.20 --dev --ignore-workspace-root-check
+      - script/install_packages vue@3.2.20
       - mono test --package=@appsignal/vue
     - name: "@appsignal/vue - vue@2.6.14"
       commands:
-      - yarn add vue@2.6.14 --dev --ignore-workspace-root-check
+      - script/install_packages vue@2.6.14
       - mono test --package=@appsignal/vue

--- a/Rakefile
+++ b/Rakefile
@@ -54,7 +54,7 @@ namespace :build_matrix do
               packages = dependency_specification.map do |name, version|
                 "#{name}@#{version}"
               end.join(" ")
-              "yarn add #{packages} --dev --ignore-workspace-root-check"
+              "script/install_packages #{packages}"
             end
 
           next unless has_package_tests

--- a/Rakefile
+++ b/Rakefile
@@ -49,34 +49,23 @@ namespace :build_matrix do
         package["variations"].each do |variation|
           variation_name = variation.fetch("name")
           dependency_specification = variation["packages"]
-          update_package_version_command, update_test_app_version_command =
+          update_package_version_command =
             if dependency_specification
               packages = dependency_specification.map do |name, version|
                 "#{name}@#{version}"
               end.join(" ")
-              [
-                "yarn add #{packages} --dev --ignore-workspace-root-check",
-                "script/install_test_example_packages " \
-                  "#{File.basename package["path"]} #{packages}"
-              ]
+              "yarn add #{packages} --dev --ignore-workspace-root-check"
             end
 
-          if has_package_tests
-            test_jobs << build_semaphore_job(
-              "name" => "#{package["package"]} - #{variation_name}",
-              "commands" => ([
-                update_package_version_command,
-                "mono test --package=#{package["package"]}"
-              ] + package.fetch("extra_commands", [])).compact
-            )
-          end
+          next unless has_package_tests
 
-          package.fetch("extra_tests", []).each do |test_name, extra_tests|
-            test_jobs << build_semaphore_job(
-              "name" => "#{package["package"]} - #{variation_name} - #{test_name}",
-              "commands" => ([update_test_app_version_command] + extra_tests).compact
-            )
-          end
+          test_jobs << build_semaphore_job(
+            "name" => "#{package["package"]} - #{variation_name}",
+            "commands" => ([
+              update_package_version_command,
+              "mono test --package=#{package["package"]}"
+            ] + package.fetch("extra_commands", [])).compact
+          )
         end
       end
 

--- a/script/install_packages
+++ b/script/install_packages
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -eu
+
+echo "$ yarn add"
+yarn add --dev --ignore-workspace-root-check "$@"
+
+echo "Check installed packages"
+successfully_installed=true
+for package_item in "$@"; do
+  if echo "$package_item" | grep "@latest"; then
+    # Don't perform check for `@latest`, because the installed version number
+    # won't match
+    continue
+  fi
+
+  if ! yarn list | grep "$package_item"; then
+    successfully_installed=false
+    echo "Failed to install: $package_item"
+  fi
+done
+
+if ! $successfully_installed; then
+  echo "Installed packages:"
+  yarn list
+  exit 1
+fi


### PR DESCRIPTION
## Remove unused test apps installer script

This script is never called, because we don't have any integration apps
at the moment to run. Also, the `install_test_example_packages` file
does not exist.

Remove it to avoid confusion.

## Check if the correct package version is installed

Move the `yarn add` command to install certain versions of packages to
a separate script so it's also possible to verify if the right versions
of the package are installed afterwards. This gives us more confidence
if the tests matrix works as intended.

It skips the `latest` version, because it won't know what version will
actually be installed.

Related to https://github.com/appsignal/appsignal-nodejs/pull/585
[skip changeset]
