### PR TITLE
Fix Vue3 with TypeScript compatibility

### DIFF
--- a/packages/vue/.changesets/fix-vue3-typescript-compatibility.md
+++ b/packages/vue/.changesets/fix-vue3-typescript-compatibility.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fixed a bug that was preventing Vue3 apps written in TypeScript from starting up.

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,10 +1,10 @@
-import { VueApp, VueViewModel } from "./types"
+import { VueApp } from "./types"
 import type { JSClient } from "@appsignal/types"
 
 export function errorHandler(appsignal: JSClient, app?: VueApp) {
   const version = app?.version ?? ""
 
-  return function (error: Error, vm: VueViewModel, info: string) {
+  return function (error: any, vm: any, info: string) {
     const componentName = vm.$vnode
       ? vm.$vnode.componentOptions.tag // Vue 2
       : vm.$options.name // Vue 3

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -1,12 +1,3 @@
-export type VueViewModel = {
-  $vnode: {
-    [key: string]: any
-  }
-  $options: {
-    [key: string]: any
-  }
-}
-
 export type VueApp = {
   version: string
 }


### PR DESCRIPTION
Vue3 error handler instance type is completely different from the Vue2
one. It can also be `null`, making duck typing pointless. Error
instances types have also changed and they're of type `unknown`.

This commit changes the `errorHandler` returned function to accept
errors and Vue objects of any type.

Fixes: https://github.com/appsignal/support/issues/186