### PR TITLE
Don't track thrown non-error objects as errors

### DIFF
--- a/packages/javascript/.changesets/non-error-objects-are-now-ignored.md
+++ b/packages/javascript/.changesets/non-error-objects-are-now-ignored.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Thrown non-error objects are now ignored instead of being reported with a generic message.

--- a/packages/javascript/src/__tests__/span.test.ts
+++ b/packages/javascript/src/__tests__/span.test.ts
@@ -20,56 +20,10 @@ describe("Span", () => {
       expect(span.serialize().error.message).toEqual("No error has been set")
     })
 
-    describe("bad input", () => {
-      it("handles strings", () => {
-        span.setError(("a string" as unknown) as Error)
-        expect(span.serialize().error.message).toEqual(
-          "setError received an invalid object or type which did not provide an error message or was not an object with a valid message property.\n\nHere's some more information about what we received:\n\n" +
-            `typeof: string\n` +
-            `constructor.name: String\n` +
-            `As a string: "a string"`
-        )
-      })
-
-      it("handles numbers", () => {
-        span.setError((123 as unknown) as Error)
-        expect(span.serialize().error.message).toEqual(
-          "setError received an invalid object or type which did not provide an error message or was not an object with a valid message property.\n\nHere's some more information about what we received:\n\n" +
-            `typeof: number\n` +
-            `constructor.name: Number\n` +
-            `As a string: "123"`
-        )
-      })
-
-      it("handles booleans", () => {
-        span.setError((true as unknown) as Error)
-        expect(span.serialize().error.message).toEqual(
-          "setError received an invalid object or type which did not provide an error message or was not an object with a valid message property.\n\nHere's some more information about what we received:\n\n" +
-            `typeof: boolean\n` +
-            `constructor.name: Boolean\n` +
-            `As a string: "true"`
-        )
-      })
-
-      it("handles arrays", () => {
-        span.setError(([] as unknown) as Error)
-        expect(span.serialize().error.message).toEqual(
-          "setError received an invalid object or type which did not provide an error message or was not an object with a valid message property.\n\nHere's some more information about what we received:\n\n" +
-            `typeof: object\n` +
-            `constructor.name: Array\n` +
-            `As a string: "[]"`
-        )
-      })
-
-      it("handles objects", () => {
-        span.setError(({} as unknown) as Error)
-        expect(span.serialize().error.message).toEqual(
-          "setError received an invalid object or type which did not provide an error message or was not an object with a valid message property.\n\nHere's some more information about what we received:\n\n" +
-            `typeof: object\n` +
-            `constructor.name: Object\n` +
-            `As a string: "{}"`
-        )
-      })
+    it("returns the span when the passed object is not an error", () => {
+      const event = new CloseEvent("event")
+      span.setError((event as unknown) as Error)
+      expect(span.serialize().error.message).toEqual("No error has been set")
     })
   })
 })

--- a/packages/javascript/src/span.ts
+++ b/packages/javascript/src/span.ts
@@ -1,4 +1,9 @@
-import { Serializable, getStacktrace, toHashMapString } from "@appsignal/core"
+import {
+  Serializable,
+  getStacktrace,
+  toHashMapString,
+  isError
+} from "@appsignal/core"
 import type {
   JSSpanData,
   Breadcrumb,
@@ -39,20 +44,11 @@ export class Span extends Serializable<JSSpanData> {
   }
 
   public setError<T extends Error>(error: Error | T): this {
-    if (!error) return this
+    if (!error || !isError(error)) return this
 
     this._data.error = {
       name: error.name || "[unknown]",
-      message:
-        error.message ||
-        "setError received an invalid object or type which did not provide an error message or was not an object with a valid message property.\n\nHere's some more information about what we received:\n\n" +
-          `typeof: ${typeof error}\n` +
-          `constructor.name: ${
-            error.constructor.name ?? "[no constructor]"
-          }\n` +
-          `As a string: "${
-            typeof error !== "string" ? JSON.stringify(error) : error
-          }"`,
+      message: error.message,
       backtrace: getStacktrace(error)
     }
 

--- a/packages/preact/.changesets/error-type-is-no-longer-checked-at-errorboundary.md
+++ b/packages/preact/.changesets/error-type-is-no-longer-checked-at-errorboundary.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "remove"
+---
+
+Remove error type check on ErrorBoundary. This is now done in the `setError` helper instead for all function calls.

--- a/packages/preact/src/ErrorBoundary.tsx
+++ b/packages/preact/src/ErrorBoundary.tsx
@@ -1,6 +1,5 @@
 import { Component } from "preact"
 import { Props, State } from "./types/component"
-import { isError } from "@appsignal/core"
 
 export class ErrorBoundary extends Component<Props, State> {
   state = { error: undefined }
@@ -10,8 +9,6 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   public componentDidCatch(error: Error, info: any): void {
-    if (!isError(error)) return
-
     const { instance: appsignal, action, tags } = this.props
     const { name, message, stack } = error
     const span = appsignal.createSpan()

--- a/packages/preact/src/__tests__/ErrorBoundary.test.tsx
+++ b/packages/preact/src/__tests__/ErrorBoundary.test.tsx
@@ -50,22 +50,6 @@ describe("<ErrorBoundary />", () => {
     expect(instance.send).toBeCalled()
   })
 
-  it("ignores non-Error objects being thrown", () => {
-    expect(() => {
-      render(
-        <ErrorBoundary instance={instance}>
-          <BrokenEvent />
-        </ErrorBoundary>
-      )
-    }).toThrow()
-
-    expect(mock.setAction).not.toBeCalled()
-    expect(mock.setTags).not.toBeCalled()
-    expect(mock.setError).not.toBeCalled()
-
-    expect(instance.send).not.toBeCalled()
-  })
-
   it("modifies the action if provided as a prop", () => {
     render(
       <ErrorBoundary instance={instance} action="testaction">

--- a/packages/react/.changesets/remove-error-type-check-on-errorboundary.md
+++ b/packages/react/.changesets/remove-error-type-check-on-errorboundary.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "remove"
+---
+
+Remove error type check on ErrorBoundary. This is now done in the `setError` helper instead for all function calls.

--- a/packages/react/src/ErrorBoundary.tsx
+++ b/packages/react/src/ErrorBoundary.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import { Props, State } from "./types/component"
-import { isError } from "@appsignal/core"
 
 export class ErrorBoundary extends React.Component<Props, State> {
   state = { error: undefined }
@@ -10,12 +9,10 @@ export class ErrorBoundary extends React.Component<Props, State> {
   }
 
   static getDerivedStateFromError(error: Error): State {
-    return isError(error) ? { error } : {}
+    return { error }
   }
 
   public componentDidCatch(error: Error): void {
-    if (!isError(error)) return
-
     const { instance: appsignal, action, tags = {} } = this.props
     const span = appsignal.createSpan()
 

--- a/packages/react/src/__tests__/ErrorBoundary.test.tsx
+++ b/packages/react/src/__tests__/ErrorBoundary.test.tsx
@@ -51,22 +51,6 @@ describe("<ErrorBoundary />", () => {
     expect(instance.send).toBeCalled()
   })
 
-  it("ignores non-Error objects being thrown", () => {
-    expect(() => {
-      render(
-        <ErrorBoundary instance={instance} fallback={() => <div>Fallback</div>}>
-          <BrokenEvent />
-        </ErrorBoundary>
-      )
-    }).toThrow(Event)
-
-    expect(mock.setAction).not.toBeCalled()
-    expect(mock.setTags).not.toBeCalled()
-    expect(mock.setError).not.toBeCalled()
-
-    expect(instance.send).not.toBeCalled()
-  })
-
   it("modifies the action if provided as a prop", () => {
     render(
       <ErrorBoundary instance={instance} action="testaction">


### PR DESCRIPTION
Remove the behaviour that accepted non-error objects in the setError()
function and added a long message to them that didn't provide useful
information.

Now any object that doesn't behave as an error will be ignored by the
setError() function. The long fallback message has also been removed.

