### PR TITLE
Add changeset for React 18 compatibility

### DIFF
--- a/packages/react/.changesets/add-react-18-compatibility.md
+++ b/packages/react/.changesets/add-react-18-compatibility.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add React 18 compatibility


### PR DESCRIPTION
We added React 18 compatibility in our tests and for that, we updated
the integration package.json file. This update is also necessary for
users that want to use React 18. This commit adds a changeset so we can
publish those changes to NPM.

Related PR: https://github.com/appsignal/appsignal-javascript/pull/567