### PR TITLE
Update preact versions in build matrix

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -115,13 +115,13 @@ blocks:
       commands:
       - script/install_packages preact@latest
       - mono test --package=@appsignal/preact
-    - name: "@appsignal/preact - preact@10.5.15"
+    - name: "@appsignal/preact - preact@10.7.3"
       commands:
-      - script/install_packages preact@10.5.15
+      - script/install_packages preact@10.7.3
       - mono test --package=@appsignal/preact
-    - name: "@appsignal/preact - preact@10.4.8"
+    - name: "@appsignal/preact - preact@10.6.6"
       commands:
-      - script/install_packages preact@10.4.8
+      - script/install_packages preact@10.6.6
       - mono test --package=@appsignal/preact
     - name: "@appsignal/react - react@latest"
       commands:

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -116,12 +116,12 @@ matrix:
         - name: "preact@latest"
           packages:
             preact: "latest"
-        - name: "preact@10.5.15"
+        - name: "preact@10.7.3"
           packages:
-            preact: "10.5.15"
-        - name: "preact@10.4.8"
+            preact: "10.7.3"
+        - name: "preact@10.6.6"
           packages:
-            preact: "10.4.8"
+            preact: "10.6.6"
     - package: "@appsignal/react"
       path: "packages/react"
       variations:


### PR DESCRIPTION
Preact released version 10.8.0 and we had our matrix for it a bit
outdated. Now it's updated with the latest minor versions.