### PR TITLE
Fix diagnose CLI send report options

### DIFF
--- a/packages/cli/.changesets/fix-send-report-cli-flags-for-diagnose-tool.md
+++ b/packages/cli/.changesets/fix-send-report-cli-flags-for-diagnose-tool.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix the send report CLI flags for diagnose tool. The documented `--send-report` and `--no-send-report` flags will now work.

--- a/packages/cli/src/commands/diagnose.ts
+++ b/packages/cli/src/commands/diagnose.ts
@@ -9,8 +9,9 @@ import { checkForAppsignalPackage } from "../utils"
  * Options:
  * -e, --environment <env>  Which environment to use
  * -k, --api-key <key>      Which API key to use
- * -h, --help               display help for command
- * --no-report              Don't send report automatically send the report to AppSignal
+ * -h, --help               Display help for command
+ * --send-report            Automatically send the report to AppSignal
+ * --no-send-report         Don't send the report automatically to AppSignal
  *
  * This command just spawns the diagnose command from the `@appsignal/nodejs`
  * package as a child process.
@@ -18,11 +19,11 @@ import { checkForAppsignalPackage } from "../utils"
 export const diagnose = ({
   apiKey,
   environment,
-  report = true
+  sendReport
 }: {
   apiKey?: string
   environment?: string
-  report: boolean
+  sendReport: boolean | undefined
 }): void => {
   const cwd = process.cwd()
 
@@ -36,12 +37,18 @@ export const diagnose = ({
     process.env["APPSIGNAL_APP_ENV"] = environment
   }
 
-  spawnSync(
-    `${cwd}/node_modules/@appsignal/nodejs/bin/diagnose`,
-    !report ? ["--no-report"] : undefined,
-    {
-      cwd,
-      stdio: "inherit"
-    }
-  )
+  let args = []
+  switch (sendReport) {
+    case true:
+      args.push("--send-report")
+      break
+    case false:
+      args.push("--no-send-report")
+      break
+  }
+
+  spawnSync(`${cwd}/node_modules/@appsignal/nodejs/bin/diagnose`, args, {
+    cwd,
+    stdio: "inherit"
+  })
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,9 +22,10 @@ export class CLI {
       .description("runs the diagnose command (Node.js integration only)")
       .option("-e, --environment <env>", "Which environment to use")
       .option("-k, --api-key <key>", "Which API key to use")
+      .option("--send-report", "Automatically send the report to AppSignal")
       .option(
-        "--no-report",
-        "Don't send report automatically send the report to AppSignal"
+        "--no-send-report",
+        "Don't send the report automatically to AppSignal"
       )
       .action(diagnose)
 


### PR DESCRIPTION
The `--no-report` option doesn't match what we have documented how our
diagnose tool works:
https://docs.appsignal.com/nodejs/command-line/diagnose.html

This creates problems for people trying to use the documented
`--send-report` and `--no-send-report` options, which we agreed upon how
this CLI should work.

I've updated the implementation to match our docs. The options can be
set or not, and they are passed to the CLI implementation in the Node.js
package.

Part of https://github.com/appsignal/support/issues/204