### PR TITLE
Extract message from Error rejection

### DIFF
--- a/packages/core/.changesets/iserror-handle-undefined.md
+++ b/packages/core/.changesets/iserror-handle-undefined.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix `isError` so that it does not throw an error when the given error is not an object.

--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -7,6 +7,7 @@
  */
 export function isError<T extends Error>(error: Error | T): boolean {
   return (
+    typeof error === "object" &&
     typeof (error as any).message !== "undefined" &&
     (typeof (error as any).stacktrace !== "undefined" ||
       typeof (error as any)["opera#sourceloc"] !== "undefined" ||

--- a/packages/plugin-window-events/.changesets/report-unhandled-rejection-errors.md
+++ b/packages/plugin-window-events/.changesets/report-unhandled-rejection-errors.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix the behaviour of the unhandled rejection handler when the reason for the rejection event (the value passed to `reject` in the promise callback) is an `Error`, showing the message and stacktrace for that error.

--- a/packages/plugin-window-events/package.json
+++ b/packages/plugin-window-events/package.json
@@ -22,7 +22,8 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@appsignal/types": "=3.0.0"
+    "@appsignal/types": "=3.0.0",
+    "@appsignal/core": "=1.1.17"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-window-events/src/__tests__/index.test.ts
+++ b/packages/plugin-window-events/src/__tests__/index.test.ts
@@ -71,8 +71,7 @@ describe("windowEventsPlugin", () => {
 
       expect(setErrorMock).toHaveBeenCalledWith({
         name: "UnhandledPromiseRejectionError",
-        message: "test",
-        stack: "No stacktrace available"
+        message: "test"
       })
     })
 
@@ -86,11 +85,7 @@ describe("windowEventsPlugin", () => {
 
       expect(mockAppsignal.createSpan).toHaveBeenCalled()
 
-      expect(setErrorMock).toHaveBeenCalledWith({
-        name: "UnhandledPromiseRejectionError",
-        message: "{}",
-        stack: error.stack
-      })
+      expect(setErrorMock).toHaveBeenCalledWith(error)
     })
 
     it("handles a promise rejection with an circular structure as a reason", () => {
@@ -114,8 +109,7 @@ describe("windowEventsPlugin", () => {
         message:
           `{"abc":"def","foo":"bar",` +
           `"reason":"[cyclic value: root object]",` +
-          `"nested":{"inside":"[cyclic value: nested]"}}`,
-        stack: "No stacktrace available"
+          `"nested":{"inside":"[cyclic value: nested]"}}`
       })
     })
 
@@ -128,8 +122,7 @@ describe("windowEventsPlugin", () => {
 
       expect(setErrorMock).toHaveBeenCalledWith({
         name: "UnhandledPromiseRejectionError",
-        message: undefined,
-        stack: "No stacktrace available"
+        message: ""
       })
     })
 
@@ -142,8 +135,7 @@ describe("windowEventsPlugin", () => {
 
       expect(setErrorMock).toHaveBeenCalledWith({
         name: "UnhandledPromiseRejectionError",
-        message: undefined,
-        stack: "No stacktrace available"
+        message: ""
       })
     })
   })


### PR DESCRIPTION
When reporting an unhandled rejection event, if the reason for the rejection (the value passed to `reject` in the promise callback) is an instance of `Error`, derive the name, message and backtrace of the resulting AppSignal error from it. This usually happens when the rejection is triggered by a `throw` inside an `async` function.

Otherwise, default to the same logic as before, reporting the error as an `UnhandledPromiseRejectionError` and serialising the reason as a JSON to use that as the error message. The message "No stacktrace available" where the stacktrace should be is already added by the `getStacktrace` function that is invoked by `span.setError`, so it does not need to be added here.

Fixes appsignal/support#210.
