### PR TITLE
Bump React peer dependency to allow 18.2.x

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -127,6 +127,10 @@ blocks:
       commands:
       - script/install_packages react@latest
       - mono test --package=@appsignal/react
+    - name: "@appsignal/react - react@18.2.0"
+      commands:
+      - script/install_packages react@18.2.0
+      - mono test --package=@appsignal/react
     - name: "@appsignal/react - react@18.1.0"
       commands:
       - script/install_packages react@18.1.0

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -128,6 +128,9 @@ matrix:
         - name: "react@latest"
           packages:
             react: "latest"
+        - name: "react@18.2.0"
+          packages:
+            react: "18.2.0"
         - name: "react@18.1.0"
           packages:
             react: "18.1.0"

--- a/packages/react/.changesets/bump-peer-dependency-to-allow-react-18-2.md
+++ b/packages/react/.changesets/bump-peer-dependency-to-allow-react-18-2.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Bump peer dependency to allow React 18.2

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -26,7 +26,7 @@
     "@appsignal/core": "=1.1.17"
   },
   "peerDependencies": {
-    "react": ">= 16.8.6 <= 18.1.0"
+    "react": ">= 16.8.6 < 19"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Also add it to the build matrix.

Fixes #576.