### PR TITLE
adds option to silence the browser console

### DIFF
--- a/packages/plugin-breadcrumbs-console/src/__tests__/silenced.test.ts
+++ b/packages/plugin-breadcrumbs-console/src/__tests__/silenced.test.ts
@@ -1,0 +1,65 @@
+import type { JSClient } from "@appsignal/types"
+import { plugin } from "../index"
+
+describe("BreadcrumbsConsolePlugin - console silenced", () => {
+  const debugMock = jest.spyOn(console, "debug").mockImplementation(() => {})
+  const infoMock = jest.spyOn(console, "info").mockImplementation(() => {})
+  const warnMock = jest.spyOn(console, "warn").mockImplementation(() => {})
+  const addBreadcrumb = jest.fn()
+
+  const mockAppsignal = ({addBreadcrumb} as unknown) as JSClient
+  plugin({silenceConsoleMethods: ["debug", "info"]}).call(mockAppsignal)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("when console.debug is called", () => {
+    it("adds breadcrumb", () => {
+      const message = "This is a debug message"
+      console.debug(message)
+
+      expect(debugMock).not.toHaveBeenCalledWith(message)
+      expect(addBreadcrumb).toHaveBeenCalledWith({
+        action: "Console logged a value",
+        category: "console.debug",
+        metadata: {
+          argument0: message
+        }
+      })
+    })
+  })
+
+  describe("when console.info is called", () => {
+    it("adds breadcrumb", () => {
+      const message = "This is an info message"
+      console.info(message)
+
+      expect(infoMock).not.toHaveBeenCalledWith(message)
+      expect(addBreadcrumb).toHaveBeenCalledWith({
+        action: "Console logged a value",
+        category: "console.info",
+        metadata: {
+          argument0: message
+        }
+      })
+    })
+  })
+
+  describe("when console.warn is called", () => {
+    it("adds breadcrumb", () => {
+      const message = "This is a warn message"
+      console.warn(message)
+
+      expect(warnMock).toHaveBeenCalledWith(message)
+      expect(addBreadcrumb).toHaveBeenCalledWith({
+        action: "Console logged a value",
+        category: "console.warn",
+        metadata: {
+          argument0: message
+        }
+      })
+    })
+  })
+
+})

--- a/packages/plugin-breadcrumbs-console/src/index.ts
+++ b/packages/plugin-breadcrumbs-console/src/index.ts
@@ -10,7 +10,6 @@ function consoleBreadcrumbsPlugin(options?: { [key: string]: any }) {
   )
 
   const silenceMethods: string[] = options?.silenceConsoleMethods ?? []
-  console.log("silenceMethods", JSON.stringify(silenceMethods));
 
   return function (this: JSClient) {
     const self = this

--- a/packages/plugin-breadcrumbs-console/src/index.ts
+++ b/packages/plugin-breadcrumbs-console/src/index.ts
@@ -9,6 +9,9 @@ function consoleBreadcrumbsPlugin(options?: { [key: string]: any }) {
       typeof (console as any)[method] === "function"
   )
 
+  const silenceMethods: string[] = options?.silenceConsoleMethods ?? []
+  console.log("silenceMethods", JSON.stringify(silenceMethods));
+
   return function (this: JSClient) {
     const self = this
 
@@ -37,7 +40,9 @@ function consoleBreadcrumbsPlugin(options?: { [key: string]: any }) {
 
         self.addBreadcrumb(breadcrumb)
 
-        prevHandler.apply(console, args)
+        if (!silenceMethods.includes(method)) {
+          prevHandler.apply(console, args)
+        }
       }
 
       ;(console as any)[method] = _console


### PR DESCRIPTION
When switching to production mode, I find myself in need to remove all debug logging; I don't want to mess up our customer's browser's developer console.

However, these logs are beneficial as Appsignal error report breadcrumbs (being the reason for the existence of the plugin-breadcrumbs-console).

I added an option `silenceConsoleMethods` to the plugin, where certain console method calls are still collected as breadcrumbs but *no longer forwarded* to the original (native) `console` methods.

E.g. `console.debug` and `console.info`
```javascript
appsignal.use(plugin({silenceConsoleMethods: ["debug", "info"]}))
```