### PR TITLE
Remove stacktrace check from isError helper

### DIFF
--- a/packages/core/.changesets/stacktrace-is-no-longer-a-requirement-for-an-object-to-be-considered-an-error.md
+++ b/packages/core/.changesets/stacktrace-is-no-longer-a-requirement-for-an-object-to-be-considered-an-error.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Stacktrace is no longer a requirement for an object to be considered an error

--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -7,11 +7,7 @@
  */
 export function isError<T extends Error>(error: Error | T): boolean {
   return (
-    typeof error === "object" &&
-    typeof (error as any).message !== "undefined" &&
-    (typeof (error as any).stacktrace !== "undefined" ||
-      typeof (error as any)["opera#sourceloc"] !== "undefined" ||
-      typeof (error as any).stack !== "undefined")
+    typeof error === "object" && typeof (error as any).message !== "undefined"
   )
 }
 


### PR DESCRIPTION
For an object to be considered an error among frameworks it's required to have a `message` attribute and to be an object. Stacktrace information is usually an extra.

The old `isError()` behaviour discarded objects without stacktraces making some of them invisible to customers.

This commit changes the check to consider an object as an error if it has a message attribute.

Fixes: #583 