### PR TITLE
Update Node.js documentation links

### DIFF
--- a/packages/cli/.changesets/update-docs-links.md
+++ b/packages/cli/.changesets/update-docs-links.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Update Node.js documentation links. The docs have moved to a v3 sub section.

--- a/packages/cli/src/__tests__/installer.test.ts
+++ b/packages/cli/src/__tests__/installer.test.ts
@@ -52,7 +52,7 @@ describe("Installer", () => {
         [`    node --require './appsignal.cjs' index.js`],
         [],
         [
-          `Some integrations require additional setup. See https://docs.appsignal.com/nodejs/integrations/ for more information.
+          `Some integrations require additional setup. See https://docs.appsignal.com/nodejs/3.x/integrations.html for more information.
 
 Need any further help? Feel free to ask a human at support@appsignal.com!`
         ]
@@ -163,7 +163,7 @@ Need any further help? Feel free to ask a human at support@appsignal.com!`
         [`    node --require './appsignal.cjs' index.js`],
         [],
         [
-          `Some integrations require additional setup. See https://docs.appsignal.com/nodejs/integrations/ for more information.
+          `Some integrations require additional setup. See https://docs.appsignal.com/nodejs/3.x/integrations.html for more information.
 
 Need any further help? Feel free to ask a human at support@appsignal.com!`
         ]
@@ -312,11 +312,11 @@ Need any further help? Feel free to ask a human at support@appsignal.com!`
 
 If you're using a cloud provider such as Heroku etc., seperate instructions on how to add these environment variables are available in our documentation:
 
- 🔗 https://docs.appsignal.com/nodejs/configuration`
+ 🔗 https://docs.appsignal.com/nodejs/3.x/configuration.html`
         ],
         [],
         [
-          `Some integrations require additional setup. See https://docs.appsignal.com/nodejs/integrations/ for more information.
+          `Some integrations require additional setup. See https://docs.appsignal.com/nodejs/3.x/integrations.html for more information.
 
 Need any further help? Feel free to ask a human at support@appsignal.com!`
         ]

--- a/packages/cli/src/installers/node/index.ts
+++ b/packages/cli/src/installers/node/index.ts
@@ -123,12 +123,12 @@ export async function installNode(dir: string) {
 
 If you're using a cloud provider such as Heroku etc., seperate instructions on how to add these environment variables are available in our documentation:
 
- 🔗 https://docs.appsignal.com/nodejs/configuration`)
+ 🔗 https://docs.appsignal.com/nodejs/3.x/configuration.html`)
     }
 
     console.log()
 
-    console.log(`Some integrations require additional setup. See https://docs.appsignal.com/nodejs/integrations/ for more information.
+    console.log(`Some integrations require additional setup. See https://docs.appsignal.com/nodejs/3.x/integrations.html for more information.
 
 Need any further help? Feel free to ask a human at ${chalk.bold(
       "support@appsignal.com"


### PR DESCRIPTION
The docs have moved to a v3 sub section.

Part of https://github.com/appsignal/support/issues/229