### PR TITLE
Fix CloudFlare Workers bug

### DIFF
--- a/packages/javascript/.changesets/fix-origin-detection-on-cloudflare-workers.md
+++ b/packages/javascript/.changesets/fix-origin-detection-on-cloudflare-workers.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix origin detection on CloudFlare workers

--- a/packages/javascript/src/environment.ts
+++ b/packages/javascript/src/environment.ts
@@ -20,10 +20,7 @@ export class Environment {
     const globals = getGlobalObject<Window>()
 
     // environments like nodejs or react native where an origin isn't relavent
-    if (
-      !globals.navigator ||
-      (globals.navigator.product === "ReactNative" && !globals.location)
-    ) {
+    if (!globals.location) {
       return ""
     }
 


### PR DESCRIPTION
If there's no location object, don't try to access the location object. Instead of trying to determine whether there will be a location object by checking the navigator object, determine whether there is a location object by checking the location object.

This fixes an issue with CloudFlare's module workers, which have a navigator object, but no location object.

Fixes appsignal/support#237.