### PR TITLE
Relax peerDependencies Stimulus versions

### DIFF
--- a/packages/stimulus/package.json
+++ b/packages/stimulus/package.json
@@ -25,7 +25,7 @@
     "@appsignal/types": "=3.0.0"
   },
   "peerDependencies": {
-    "stimulus": "^1.1.1"
+    "stimulus": "^1.1 || ^3.2"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
As Stimulus 3.x versions have been released for a long time, and this plugin works perfectly well with it, removing this warning would be appreciated:

```
warning " > @appsignal/stimulus@1.0.15" has unmet peer dependency "stimulus@^1.1.1".
```