### PR TITLE
Fix warning when using `@hotwired/stimulus`

### DIFF
--- a/packages/stimulus/.changesets/remove-peer-dependency-warning-for-stimulus-3.md
+++ b/packages/stimulus/.changesets/remove-peer-dependency-warning-for-stimulus-3.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Remove peer dependency warning for Stimulus 3 when using the `@hotwired/stimulus` package.

--- a/packages/stimulus/package.json
+++ b/packages/stimulus/package.json
@@ -25,7 +25,16 @@
     "@appsignal/types": "=3.0.0"
   },
   "peerDependencies": {
-    "stimulus": "^1.1 || ^3.2"
+    "stimulus": "^1.1",
+    "@hotwired/stimulus": "^3.0"
+  },
+  "peerDependenciesMeta": {
+    "stimulus": {
+      "optional": true
+    },
+    "@hotwired/stimulus": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
To avoid an `unmetPeerDependency` warning when using the `@hotwired/stimulus` package (version 3 and above) instead of the previous `stimulus` package, mark both of the packages as optional peer dependencies.

Fixes #593.

---

@czj Please take a look! Does this fix the issue in an acceptable manner?