### PR TITLE
Fix Electron build with dynamic HTTPS import

### DIFF
--- a/packages/javascript/.changesets/fix-attempt-to-use-https-in-electron.md
+++ b/packages/javascript/.changesets/fix-attempt-to-use-https-in-electron.md
@@ -1,0 +1,12 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Attempt to import the `http` and `https` module dynamically. This fixes
+an issue with Electron, which does not expose the `https` module.
+
+Emit a warning if `NodeTransport` is used but the `https` module fails to be imported.
+
+This allows Electron users to use the AppSignal integration alongside
+with the `electron-fetch` library.

--- a/packages/javascript/tsconfig.esm.json
+++ b/packages/javascript/tsconfig.esm.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist/esm",
-    "module": "es6",
+    "module": "es2020",
     "importHelpers": true
   }
 }


### PR DESCRIPTION
Draft PR for the #596 pre-release branch. This probably does fix the immediate issue when importing the integration from Electron, but probably does not make our integration work with Electron (at least not when Electron is not exposing the Node.js native `http`/`https` modules)

## [Dynamically import https module in NodeTransport](https://github.com/appsignal/appsignal-javascript/commit/b9be69158507c88007fa5da33007464ba652eaa4)

In Electron, `https` is not available for import. Importing it
dynamically might fix the issue, if Electron does not attempt to
use the NodeTransport.

Bump the module support to `"es2020"`, which allows for dynamic
imports. This affects what module system is accepted, not what is
emitted.

## [Warn if HTTPS cannot be imported](https://github.com/appsignal/appsignal-javascript/commit/9bd47d685e3919167fb8b5bbd39d8c35093f38b3)

Emit a console warning if the NodeTransport is used in a context
where HTTPS is not available.