### PR TITLE
Report errors when running the diagnose

### DIFF
--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,19 +1,34 @@
+import { existsSync } from "fs"
+
 export function checkForAppsignalPackage() {
+  console.log("🔭 Checking for @appsignal/nodejs...")
+
   try {
-    console.log("🔭 Checking your package.json for @appsignal/nodejs...")
     const pkg = require(`${process.cwd()}/package.json`)
 
     if (!("@appsignal/nodejs" in (pkg.dependencies || {}))) {
-      console.error("Couldn't find @appsignal/nodejs in your dependencies")
+      console.error(
+        "Couldn't find @appsignal/nodejs in your dependencies. Exiting."
+      )
+
       process.exit(1)
     }
-
-    console.log("✅ Found it!")
   } catch (e) {
     console.error(
-      "Couldn't find a package.json in your current working directory"
+      "Couldn't find a package.json in your current working directory. Exiting."
     )
 
     process.exit(1)
   }
+
+  if (!existsSync(`${process.cwd()}/node_modules/@appsignal/nodejs`)) {
+    console.error(
+      "Couldn't find the `@appsignal/nodejs` package in your `node_modules` folder."
+    )
+    console.error("Please run `npm install` and try again. Exiting.")
+
+    process.exit(1)
+  }
+
+  console.log("✅ Found it!")
 }


### PR DESCRIPTION
In the `checkForAppsignalPackage` function in `utils.ts`, which is used by both the diagnose and demo commands, check that the package is not only present in the `package.json` dependencies, but in the `node_modules` folder. This is an implicit expectation of both commands.

In the diagnose command, if calling `spawnSync` returns (but not raises!) an error, log that error and exit. Before attempting to spawn the command, check for executable permissions to it, and log a specific error and exit if we do not have execute permissions for the diagnose command.