### PR TITLE
Add the config flag to the diagnose command

### DIFF
--- a/packages/cli/.changesets/add-the-config-flag-to-the-diagnose-command.md
+++ b/packages/cli/.changesets/add-the-config-flag-to-the-diagnose-command.md
@@ -1,0 +1,7 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add the config flag to the diagnose command to specify to the diagnose the user's AppSignal configuration file
+if it is not the default one.

--- a/packages/cli/src/commands/diagnose.ts
+++ b/packages/cli/src/commands/diagnose.ts
@@ -13,6 +13,7 @@ import { accessSync, constants } from "fs"
  * -h, --help               Display help for command
  * --send-report            Automatically send the report to AppSignal
  * --no-send-report         Don't send the report automatically to AppSignal
+ * --config                 Location of a custom AppSignal configuration file if any
  *
  * This command just spawns the diagnose command from the `@appsignal/nodejs`
  * package as a child process.
@@ -20,10 +21,12 @@ import { accessSync, constants } from "fs"
 export const diagnose = ({
   apiKey,
   environment,
-  sendReport
+  sendReport,
+  config
 }: {
   apiKey?: string
   environment?: string
+  config?: string
   sendReport: boolean | undefined
 }): void => {
   const cwd = process.cwd()
@@ -39,6 +42,10 @@ export const diagnose = ({
   }
 
   let args = []
+  if (config) {
+    args.push("--config", config)
+  }
+
   switch (sendReport) {
     case true:
       args.push("--send-report")

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,6 +22,10 @@ export class CLI {
       .description("runs the diagnose command (Node.js integration only)")
       .option("-e, --environment <env>", "Which environment to use")
       .option("-k, --api-key <key>", "Which API key to use")
+      .option(
+        "-c, --config <path>",
+        "The location of the AppSignal configuration file if it's not the default one"
+      )
       .option("--send-report", "Automatically send the report to AppSignal")
       .option(
         "--no-send-report",


### PR DESCRIPTION
Allows the user to specify a config file other than the default one to the diagnose.

This is required to make it work on the Node.js integration.