### PR TITLE
Look for `node_modules` in parent folders

### DIFF
--- a/packages/cli/src/commands/demo.ts
+++ b/packages/cli/src/commands/demo.ts
@@ -11,7 +11,7 @@ export function demo({
   environment?: string
   application?: string
 }): void {
-  checkForAppsignalPackage()
+  const packageRoot = checkForAppsignalPackage()
 
   if (apiKey) {
     process.env["APPSIGNAL_PUSH_API_KEY"] = apiKey
@@ -25,16 +25,22 @@ export function demo({
     process.env["APPSIGNAL_APP_NAME"] = application
   }
 
-  spawnDemo()
+  spawnDemo({}, packageRoot)
 }
 
-export function spawnDemo(env: { [key: string]: string } = {}): void {
+export function spawnDemo(
+  env: { [key: string]: string } = {},
+  packageRoot?: string
+): void {
+  packageRoot = packageRoot ?? `${process.cwd()}/node_modules/@appsignal/nodejs`
+
   spawn("node", [__filename], {
     cwd: process.cwd(),
     detached: true,
     env: {
       ...process.env,
-      ...env
+      ...env,
+      _APPSIGNAL_NODE_MODULE_PACKAGE_ROOT: packageRoot
     },
     stdio: "ignore"
   }).unref()
@@ -51,9 +57,9 @@ export function spawnDemo(env: { [key: string]: string } = {}): void {
 }
 
 if (require.main === module) {
-  const {
-    Appsignal
-  } = require(`${process.cwd()}/node_modules/@appsignal/nodejs/dist`)
+  const packageRoot = process.env["_APPSIGNAL_NODE_MODULE_PACKAGE_ROOT"]
+
+  const { Appsignal } = require(`${packageRoot}/dist`)
 
   const appsignal = new Appsignal({ active: true })
 

--- a/packages/cli/src/commands/diagnose.ts
+++ b/packages/cli/src/commands/diagnose.ts
@@ -28,7 +28,7 @@ export const diagnose = ({
 }): void => {
   const cwd = process.cwd()
 
-  checkForAppsignalPackage()
+  const packageRoot = checkForAppsignalPackage()
 
   if (apiKey) {
     process.env["APPSIGNAL_PUSH_API_KEY"] = apiKey
@@ -49,10 +49,7 @@ export const diagnose = ({
   }
 
   try {
-    accessSync(
-      `${cwd}/node_modules/@appsignal/nodejs/bin/diagnose`,
-      constants.X_OK
-    )
+    accessSync(`${packageRoot}/bin/diagnose`, constants.X_OK)
   } catch (e) {
     console.error("Didn't have permissions to execute the diagnose binary.")
     console.error(
@@ -62,11 +59,10 @@ export const diagnose = ({
     process.exit(1)
   }
 
-  const result = spawnSync(
-    `${cwd}/node_modules/@appsignal/nodejs/bin/diagnose`,
-    args,
-    { cwd, stdio: "inherit" }
-  )
+  const result = spawnSync(`${packageRoot}/bin/diagnose`, args, {
+    cwd,
+    stdio: "inherit"
+  })
 
   if (result.error) {
     console.error("Something went wrong when executing the diagnose report:")

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,6 +1,9 @@
 import { existsSync } from "fs"
+import { dirname } from "path"
 
-export function checkForAppsignalPackage() {
+// Returns the filesystem location at which the root of the
+// `@appsignal/nodejs` package was found.
+export function checkForAppsignalPackage(): string {
   console.log("🔭 Checking for @appsignal/nodejs...")
 
   try {
@@ -21,14 +24,25 @@ export function checkForAppsignalPackage() {
     process.exit(1)
   }
 
-  if (!existsSync(`${process.cwd()}/node_modules/@appsignal/nodejs`)) {
-    console.error(
-      "Couldn't find the `@appsignal/nodejs` package in your `node_modules` folder."
-    )
-    console.error("Please run `npm install` and try again. Exiting.")
+  let currentRoot = process.cwd()
 
-    process.exit(1)
+  // Look for the package in parent folders (yarn workspaces)
+  while (currentRoot !== "/") {
+    const currentPath = `${currentRoot}/node_modules/@appsignal/nodejs`
+
+    if (existsSync(currentPath)) {
+      console.log(`✅ Found it! (at ${currentRoot})`)
+
+      return currentPath
+    }
+
+    currentRoot = dirname(currentRoot)
   }
 
-  console.log("✅ Found it!")
+  console.error(
+    "Couldn't find the `@appsignal/nodejs` package in your `node_modules` folder."
+  )
+  console.error("Please run `npm install` and try again. Exiting.")
+
+  process.exit(1)
 }


### PR DESCRIPTION
When using yarn workspaces, the `node_modules` folder may not be present at the package, but at the workspace root. If it's not found at the current location, traverse the filesystem up recursively until it is found or the root is reached.

Pass the location at which it was found on to callers, which will use it to invoke the diagnose or demo commands.

---

Intercom: https://app.intercom.com/a/inbox/yzor8gyw/inbox/admin/4356044/conversation/16410700232568?view=List
Slack: https://appsignal.slack.com/archives/C7XHXQ7N0/p1690536567972759

Please triple-check the demo command. It seems to work on my machine, but the way it works is so strange, I don't trust it one bit.