### PR TITLE
Make the CLI fail when config file doesn't exist

### DIFF
--- a/packages/cli/.changesets/fail-if-the-file-passed-to-flag-doesn-t-exists.md
+++ b/packages/cli/.changesets/fail-if-the-file-passed-to-flag-doesn-t-exists.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Fail if the file passed to flag doesn't exists

--- a/packages/cli/src/commands/diagnose.ts
+++ b/packages/cli/src/commands/diagnose.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "child_process"
 import { checkForAppsignalPackage } from "../utils"
-import { accessSync, constants } from "fs"
+import { existsSync, accessSync, constants } from "fs"
 
 /**
  * Usage: npx @appsignal/cli diagnose [options]
@@ -43,7 +43,14 @@ export const diagnose = ({
 
   let args = []
   if (config) {
-    args.push("--config", config)
+    if (existsSync(config)) {
+      args.push("--config", config)
+    } else {
+      console.error(
+        `The AppSignal config file '${config}' does not exist. Please check the path and try again.`
+      )
+      process.exit(1)
+    }
   }
 
   switch (sendReport) {


### PR DESCRIPTION
If the diagnose CLI command is called with the `--config` flag and the provided path doesn't exist, the CLI fails.