### PR TITLE
Remove restrictions on span params type

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,7 @@ GEM
     unicode-display_width (2.1.0)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-20
 
 DEPENDENCIES

--- a/packages/javascript/.changesets/update-types-dependency-and-remove-params-restrictions.md
+++ b/packages/javascript/.changesets/update-types-dependency-and-remove-params-restrictions.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Remove a restriction in our `setParams` TypeScript types that did not allow nested objects to be sent as params. It is now possible to send nested objects and arrays as values inside the params object.

--- a/packages/javascript/src/span.ts
+++ b/packages/javascript/src/span.ts
@@ -60,7 +60,7 @@ export class Span extends Serializable<JSSpanData> {
     return this
   }
 
-  public setParams(params: HashMap<HashMapValue>): this {
+  public setParams(params: HashMap<any>): this {
     this._data.params = { ...this._data.params, ...params }
     return this
   }

--- a/packages/types/.changesets/remove-type-restrictions-on-span-params.md
+++ b/packages/types/.changesets/remove-type-restrictions-on-span-params.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Update the type definition of our `setParams` and `params` span interfaces so that nested objects and arrays can be sent inside the params object.

--- a/packages/types/src/interfaces/span.ts
+++ b/packages/types/src/interfaces/span.ts
@@ -15,7 +15,7 @@ export interface JSSpan {
 
   setTags(tags: HashMap<string>): this
 
-  setParams(params: HashMap<HashMapValue>): this
+  setParams(params: HashMap<any>): this
 
   setBreadcrumbs(breadcrumbs: Breadcrumb[]): this
 }
@@ -30,7 +30,7 @@ export interface JSSpanData {
   error: Error
   revision?: string
   tags?: HashMap<string>
-  params?: HashMap<HashMapValue>
+  params?: HashMap<any>
   environment?: HashMap<string>
   breadcrumbs?: Breadcrumb[]
 }


### PR DESCRIPTION
The span params now allow any kind of type as it's going to be transformed into JSON.

This is a small hack to ensure compatibility until we iterate over the integration to improve it.

Closes: https://github.com/appsignal/support/issues/295