### PR TITLE
Log component name for newer versions of Vue

### DIFF
--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -7,7 +7,7 @@ export function errorHandler(appsignal: JSClient, app?: VueApp) {
   return function (error: any, vm: any, info: string) {
     const componentName = vm.$vnode
       ? vm.$vnode.componentOptions.tag // Vue 2
-      : vm.$options.name // Vue 3
+      : vm.$options.name || vm.$options.__name // Vue 3
     const span = appsignal.createSpan()
 
     span


### PR DESCRIPTION
Newer versions of vue have this information in `__name` (to be completely honest I haven't checked if `.name` ever worked, so maybe it should be completely removed, but `.__name` seems to work from vue 3.2 - 3.4.x