### PR TITLE
Add warning about committing Push API key

### DIFF
--- a/packages/cli/.changesets/warn-about-push-api-key-in-config-file.md
+++ b/packages/cli/.changesets/warn-about-push-api-key-in-config-file.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Warn about Push API key being committed in the AppSignal config file and recommend using system environment variables instead.

--- a/packages/cli/src/__tests__/installer.test.ts
+++ b/packages/cli/src/__tests__/installer.test.ts
@@ -67,6 +67,9 @@ Need any further help? Feel free to ask a human at support@appsignal.com!`
           `new Appsignal({\n` +
           `  active: true,\n` +
           `  name: "MyApp",\n` +
+          `  // Your app's AppSignal Push API key. We don't recommend committing this key.\n` +
+          `  // Set the Push API key using a system environment variable.\n` +
+          `  // pushApiKey: process.env.APPSIGNAL_PUSH_API_KEY,\n` +
           `  pushApiKey: "00000000-0000-0000-0000-000000000000",\n` +
           `});\n`
       )
@@ -178,6 +181,9 @@ Need any further help? Feel free to ask a human at support@appsignal.com!`
           `new Appsignal({\n` +
           `  active: true,\n` +
           `  name: "MyApp",\n` +
+          `  // Your app's AppSignal Push API key. We don't recommend committing this key.\n` +
+          `  // Set the Push API key using a system environment variable.\n` +
+          `  // pushApiKey: process.env.APPSIGNAL_PUSH_API_KEY,\n` +
           `  pushApiKey: "00000000-0000-0000-0000-000000000000",\n` +
           `});\n`
       )
@@ -220,6 +226,9 @@ Need any further help? Feel free to ask a human at support@appsignal.com!`
           `new Appsignal({\n` +
           `  active: true,\n` +
           `  name: "MyApp",\n` +
+          `  // Your app's AppSignal Push API key. We don't recommend committing this key.\n` +
+          `  // Set the Push API key using a system environment variable.\n` +
+          `  // pushApiKey: process.env.APPSIGNAL_PUSH_API_KEY,\n` +
           `  pushApiKey: "00000000-0000-0000-0000-000000000000",\n` +
           `});\n`
       )
@@ -263,6 +272,9 @@ Need any further help? Feel free to ask a human at support@appsignal.com!`
           `new Appsignal({\n` +
           `  active: true,\n` +
           `  name: "MyApp",\n` +
+          `  // Your app's AppSignal Push API key. We don't recommend committing this key.\n` +
+          `  // Set the Push API key using a system environment variable.\n` +
+          `  // pushApiKey: process.env.APPSIGNAL_PUSH_API_KEY,\n` +
           `  pushApiKey: "00000000-0000-0000-0000-000000000000",\n` +
           `});\n`
       )

--- a/packages/cli/src/installers/node/index.ts
+++ b/packages/cli/src/installers/node/index.ts
@@ -84,13 +84,22 @@ export async function installNode(dir: string) {
     console.log()
     console.log(`Writing ${filename} configuration file.`)
 
+    let pushApiKeyConfig = ""
+    if (useConfigFile) {
+      pushApiKeyConfig =
+        `  // Your app's AppSignal Push API key. We don't recommend committing this key.\n` +
+        `  // Set the Push API key using a system environment variable.\n` +
+        `  // pushApiKey: process.env.APPSIGNAL_PUSH_API_KEY,\n` +
+        `  pushApiKey: "${pushApiKey}",\n`
+    }
+
     fs.writeFileSync(
       path.join(dir, filename),
       `const { Appsignal } = require("@appsignal/nodejs");\n\n` +
         `new Appsignal({\n` +
         `  active: true,\n` +
         `  name: "${name}",\n` +
-        (useConfigFile ? `  pushApiKey: "${pushApiKey}",\n` : ``) +
+        pushApiKeyConfig +
         `});\n`
     )
   }


### PR DESCRIPTION
When generating an AppSignal config file, add a warning to that file about committing the Push API key key, and recommend against it.

- Related [Basecamp post](https://3.basecamp.com/4738529/buckets/18166704/messages/6933851381#__recording_6935979673).