### PR TITLE
Capture ErrorEvent

### DIFF
--- a/packages/javascript/src/index.ts
+++ b/packages/javascript/src/index.ts
@@ -117,13 +117,14 @@ export default class Appsignal implements JSClient {
     tagsOrFn?: object | ((span: Span) => T),
     namespace?: string
   ): Promise<any> | void {
-    if (!(data instanceof Error) && !(data instanceof Span) && !(data instanceof ErrorEvent)) {
+    if (!(data instanceof Error) && !(data instanceof Span) && !(data && data.error instanceof Error)) {
       // @TODO: route this through a central logger
       console.error(
         "[APPSIGNAL]: Can't send error, given error is not a valid type"
       )
       return
     }
+    if ('error' in data) data = data.error; // handle ErrorEvent
 
     // handle user defined ignores
     if (this.ignored.length !== 0) {
@@ -200,7 +201,7 @@ export default class Appsignal implements JSClient {
           span
         )
 
-        if (data instanceof Error || data instanceof ErrorEvent) {
+        if (data instanceof Error) {
           throw data
         }
       } else {


### PR DESCRIPTION
[ErrorEvent](https://developer.mozilla.org/en-US/docs/Web/API/ErrorEvent) is also a valid error in javascript, but it does not inherit from Error, it inherits from Event, so the current code doesn't work for this. This PR allows for this. I haven't tested it in production yet.

Technically anything is a valid error in javascript (eg. `raise 1;` is totally valid) but I didn't have time to rewrite the whole thing and this should fix my situation.