### PR TITLE
Support `ErrorEvent` instances as errors

### DIFF
--- a/packages/javascript/.changesets/allow--errorevent--instances-to-be-reported-to-appsignal.md
+++ b/packages/javascript/.changesets/allow--errorevent--instances-to-be-reported-to-appsignal.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Allow `ErrorEvent` instances to be reported to AppSignal.


### PR DESCRIPTION
Follow-up to #625.

Allow for an `ErrorEvent` instance (which does not inherit from `Error`, but from `Event`) to be reported to AppSignal, by unwrapping the error instance within it.