### PR TITLE
Check caught variables are errors

### DIFF
--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -1,4 +1,3 @@
-import inquirer from "inquirer"
 import { installNode } from "../installers/node"
 
 /**
@@ -17,7 +16,7 @@ export async function install() {
     console.log("✅ Done!")
     return
   } catch (error) {
-    if (error.isTtyError) {
+    if (error instanceof Error) {
       console.warn(
         "Prompt couldn't be rendered in the current environment, exiting..."
       )

--- a/packages/core/.changesets/the-package-is-now-useunknownincatchvariables-compliant.md
+++ b/packages/core/.changesets/the-package-is-now-useunknownincatchvariables-compliant.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+type: change
+---
+
+The package is now useUnknownInCatchVariables compliant.
+
+Try catch blocks in the package now check for the caught variable to be an instance of `Error` before doing any error-specific operations with it.

--- a/packages/javascript/src/__tests__/index.test.ts
+++ b/packages/javascript/src/__tests__/index.test.ts
@@ -171,7 +171,9 @@ describe("Appsignal", () => {
           throw new Error("test error")
         })
       } catch (e) {
-        expect(e.message).toEqual("test error")
+        if (e instanceof Error) {
+          expect(e.message).toEqual("test error")
+        }
       }
     })
 
@@ -189,7 +191,9 @@ describe("Appsignal", () => {
           throw new Error("test error")
         })
       } catch (e) {
-        expect(e.message).toEqual("test error")
+        if (e instanceof Error) {
+          expect(e.message).toEqual("test error")
+        }
       }
     })
 

--- a/packages/javascript/src/index.ts
+++ b/packages/javascript/src/index.ts
@@ -346,7 +346,9 @@ export default class Appsignal implements JSClient {
     try {
       return await fn()
     } catch (e) {
-      await this.sendError(e, tagsOrFn, namespace)
+      if (e instanceof Error || e instanceof ErrorEvent) {
+        await this.sendError(e, tagsOrFn, namespace)
+      }
       return Promise.reject(e)
     }
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,6 @@
 
     /* Strict Type-Checking Options */
     "strict": true,                           /* Enable all strict type-checking options. */
-    "useUnknownInCatchVariables": false,      /* Use unknown type in catched variables */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */


### PR DESCRIPTION
In order to be compliant with `useUnknownInCatchVariables` TS config option, the try/catch blocks need to check if the caught variable is an actual Error before performing any error-specific operations with it.

Closes #569 