### PR TITLE
Remove error throw in development

### DIFF
--- a/packages/javascript/.changesets/remove-error-throw-in-development-mode.md
+++ b/packages/javascript/.changesets/remove-error-throw-in-development-mode.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+type: change
+---
+
+Remove error throw in development mode when sending an error with `send/sendError`.

--- a/packages/javascript/src/index.ts
+++ b/packages/javascript/src/index.ts
@@ -213,17 +213,12 @@ export default class Appsignal implements JSClient {
       this._breadcrumbs = []
 
       // if no key is supplied, we just output the span to the console
-      // and rethrow the error
       if (!this._options.key) {
         // @TODO: route this through a central logger
         console.warn(
           "[APPSIGNAL]: Span not sent because we're in development mode:",
           span
         )
-
-        if (data instanceof Error) {
-          throw data
-        }
       } else {
         // attempt to push to the API
         return this._api.push(span).catch(() => {


### PR DESCRIPTION
When the app is in development mode our library would throw the error. This is unlike other integrations and not expected behavior to only occur in development mode.

In integrations/instrumentations of other libraries we need to rethrow errors, but here, in our own API we should not throw errors. The error will be ignored in development mode and an info log message will be printed to the console.