### PR TITLE
Do not serialise object keys in place

### DIFF
--- a/packages/core/.changesets/do-not-serialise-object-keys-in-place.md
+++ b/packages/core/.changesets/do-not-serialise-object-keys-in-place.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix an issue where objects given as tags or breadcrumb metadata would have their values modified in place.

--- a/packages/core/src/utils/__tests__/hashmap.test.ts
+++ b/packages/core/src/utils/__tests__/hashmap.test.ts
@@ -10,14 +10,36 @@ describe("toHashMap", () => {
     })
 
     if (hm) {
-      Object.values(hm).forEach(el =>
-        expect(
-          typeof el === "string" ||
-            typeof el === "number" ||
-            typeof el === "boolean"
-        ).toBeTruthy()
-      )
+      expect(hm).toStrictEqual({
+        string: "abc",
+        number: 123,
+        boolean: true,
+        object: '{"test":123}'
+      })
+    } else {
+      expect(hm).not.toBeUndefined()
     }
+  })
+
+  it("does not modify the given object", () => {
+    const obj = {
+      string: "abc",
+      number: 123,
+      boolean: true,
+      object: { test: 123 }
+    }
+
+    const hm = toHashMap(obj)
+
+    expect(obj).toStrictEqual({
+      string: "abc",
+      number: 123,
+      boolean: true,
+      object: { test: 123 }
+    })
+
+    // the object it returns should be a different object
+    expect(hm).not.toBe(obj)
   })
 
   it("returns undefined if argument is undefined", () => {
@@ -28,13 +50,44 @@ describe("toHashMap", () => {
 
 describe("toHashMapString", () => {
   it("converts all values in a flat object to a string", () => {
-    const hm = toHashMapString({ string: "abc", number: 123, boolean: true })
+    const hm = toHashMapString({
+      string: "abc",
+      number: 123,
+      boolean: true,
+      object: { test: 123 }
+    })
 
     if (hm) {
-      Object.values(hm).forEach(el =>
-        expect(typeof el === "string").toBeTruthy()
-      )
+      expect(hm).toStrictEqual({
+        string: "abc",
+        number: "123",
+        boolean: "true",
+        object: '{"test":123}'
+      })
+    } else {
+      expect(hm).not.toBeUndefined()
     }
+  })
+
+  it("does not modify the given object", () => {
+    const obj = {
+      string: "abc",
+      number: 123,
+      boolean: true,
+      object: { test: 123 }
+    }
+
+    const hm = toHashMap(obj)
+
+    expect(obj).toStrictEqual({
+      string: "abc",
+      number: 123,
+      boolean: true,
+      object: { test: 123 }
+    })
+
+    // the object it returns should be a different object
+    expect(hm).not.toBe(obj)
   })
 
   it("returns undefined if argument is undefined", () => {

--- a/packages/core/src/utils/hashmap.ts
+++ b/packages/core/src/utils/hashmap.ts
@@ -10,15 +10,17 @@ export function toHashMapString(
 ): HashMap<string> | undefined {
   if (!obj) return
 
+  const hm: HashMap<string> = {}
+
   Object.keys(obj).forEach(k => {
     if (typeof obj[k] === "object") {
-      obj[k] = JSON.stringify(obj[k])
+      hm[k] = JSON.stringify(obj[k])
+    } else {
+      hm[k] = String(obj[k])
     }
-
-    obj[k] = String(obj[k])
   })
 
-  return obj
+  return hm
 }
 
 /**
@@ -29,17 +31,19 @@ export function toHashMap(
 ): HashMap<HashMapValue> | undefined {
   if (!obj) return
 
+  const hm: HashMap<HashMapValue> = {}
+
   Object.keys(obj).forEach(k => {
     if (
       typeof obj[k] === "string" ||
       typeof obj[k] === "boolean" ||
       typeof obj[k] === "number"
     ) {
-      return
+      hm[k] = obj[k]
+    } else {
+      hm[k] = JSON.stringify(obj[k])
     }
-
-    obj[k] = JSON.stringify(obj[k])
   })
 
-  return obj
+  return hm
 }


### PR DESCRIPTION
On `toHashMap` and `toHashMapString`, which are used to normalise objects that are passed as tags and breadcrumb metadata, do not serialise the object keys in place. The object passed may be part of the customer's application, and we should not modify it.

Instead, produce a clone of said object with the serialised keys, and return that.

I have verified that every use of this utility function makes use of its return value, rather than calling it for its side effects on the original object.

Fixes #639.