### PR TITLE
Custom backtrace sanitization

### DIFF
--- a/packages/javascript/.changesets/custom-backtrace-sanitization.md
+++ b/packages/javascript/.changesets/custom-backtrace-sanitization.md
@@ -1,0 +1,38 @@
+---
+bump: minor
+type: add
+---
+
+Allow custom backtrace sanitization.
+
+> **Warning:** This is an advanced feature meant for specific use cases. For most use cases, you should not need this functionality. If in doubt, leave `matchPath` unset.
+> 
+> **Using `matchPath` will cause public sourcemap detection to fail.** If using `matchPath`, use our private sourcemap API to upload sourcemaps to AppSignal.
+
+Some applications, such as those running on Electron or React Native environments, emit backtrace lines containing paths relative to the device in which the application is running.
+
+The unpredictability of these backtrace line paths interferes with the correct functioning of backtrace error grouping, and makes it impossible to upload sourcemaps for these files using our private sourcemap API, as it is not possible to know the expected path beforehand.
+
+You can set the `matchPath` configuration to a list of one or more regexes, which will be used to attempt to match the relevant section of the backtrace line path.
+
+For example, suppose you have an Electron application, which your users install at unpredictable locations. Your backtrace line paths may look something like this, with the username changing for each installation:
+
+```sh
+/Users/${USERNAME}/Applications/CoolBeans.app/Contents/Resources/app/index.js
+```
+
+To ignore these parts of the path that are not predictable, you can configure AppSignal to ignore everything before the `app` folder as follows:
+
+```js
+const appsignal = new AppSignal({
+  matchPath: [
+    new RegExp("CoolBeans\\.app/Contents/Resources/(.*)$")
+  ]
+})
+```
+
+If set, the `matchPath` configuration option must contain a regular expression, or an array of one or more regular expressions, which attempt to match the whole backtrace line path. These regular expressions are expected to have a single match group, such as `(.*)` in the example above, which attempts to match against the relevant segments of the backtrace line path.
+
+AppSignal will attempt to match the whole backtrace line path against these regular expressions in order. If any of the regular expression matches and produces a match group, AppSignal will replace the path in the backtrace line with the matched segment.
+
+Make sure your regular expressions provide unique and stable points of reference in the path, such as `CoolBeans.app/Contents/Resources` in the example above.

--- a/packages/javascript/.changesets/custom-backtrace-sanitization.md
+++ b/packages/javascript/.changesets/custom-backtrace-sanitization.md
@@ -31,7 +31,7 @@ const appsignal = new AppSignal({
 })
 ```
 
-If set, the `matchPath` configuration option must contain a regular expression, or an array of one or more regular expressions, which attempt to match the whole backtrace line path. These regular expressions are expected to have a single match group, such as `(.*)` in the example above, which attempts to match against the relevant segments of the backtrace line path.
+If set, the `matchPath` configuration option must contain a regular expression, or an array of one or more regular expressions, which attempt to match the whole backtrace line path. These regular expressions must have one or more match groups, such as `(.*)` in the example above, which attempt to match against the relevant segments of the backtrace line path.
 
 AppSignal will attempt to match the whole backtrace line path against these regular expressions in order. If any of the regular expression matches and produces a match group, AppSignal will replace the path in the backtrace line with the matched segment.
 

--- a/packages/javascript/src/__mocks__/api.ts
+++ b/packages/javascript/src/__mocks__/api.ts
@@ -1,5 +1,7 @@
+export const pushMock = jest.fn(span => Promise.resolve(span))
+
 export const PushApi = jest.fn().mockImplementation(() => {
   return {
-    push: jest.fn(span => Promise.resolve(span))
+    push: pushMock
   }
 })

--- a/packages/javascript/src/__tests__/span.test.ts
+++ b/packages/javascript/src/__tests__/span.test.ts
@@ -72,6 +72,31 @@ describe("Span", () => {
       ])
     })
 
+    it("concatenates all match groups", () => {
+      const error = new Error("test error")
+      error.stack = [
+        "Error: test error",
+        "    at Foo (http://localhost:8080/assets/app/bundle.js:13:10)",
+        "    at Bar (http://cdn.coolbeans.app/assets/9ac54f82103a399d/app/bundle.js:17:10)",
+        "    at track (http://thirdparty.app/script.js:1:530)",
+        "    at http://cdn.coolbeans.app/assets/9ac54f82103a399d/app/bundle.js:21:10"
+      ].join("\n")
+
+      span.setError(error)
+      span.cleanBacktracePath(
+        new RegExp(".*/(assets/)(?:[0-9a-f]{16}/)?(app/.*)$")
+      )
+
+      const backtrace = span.serialize().error.backtrace
+      expect(backtrace).toEqual([
+        "Error: test error",
+        "    at Foo (assets/app/bundle.js:13:10)",
+        "    at Bar (assets/app/bundle.js:17:10)",
+        "    at track (http://thirdparty.app/script.js:1:530)",
+        "    at assets/app/bundle.js:21:10"
+      ])
+    })
+
     it("tries matchers in order", () => {
       const error = new Error("test error")
       error.stack = [

--- a/packages/javascript/src/__tests__/span.test.ts
+++ b/packages/javascript/src/__tests__/span.test.ts
@@ -26,4 +26,74 @@ describe("Span", () => {
       expect(span.serialize().error.message).toEqual("No error has been set")
     })
   })
+
+  describe("cleanBacktracePath", () => {
+    it("cleans Chrome-style backtraces", () => {
+      const error = new Error("test error")
+      error.stack = [
+        "Error: test error",
+        "    at Foo (http://localhost:8080/assets/app/bundle.js:13:10)",
+        "    at Bar (http://localhost:8080/assets/app/bundle.js:17:10)",
+        "    at track (http://thirdparty.app/script.js:1:530)",
+        "    at http://localhost:8080/assets/app/bundle.js:21:10"
+      ].join("\n")
+
+      span.setError(error)
+      span.cleanBacktracePath(new RegExp("/assets/(app/.*)$"))
+
+      const backtrace = span.serialize().error.backtrace
+      expect(backtrace).toEqual([
+        "Error: test error",
+        "    at Foo (app/bundle.js:13:10)",
+        "    at Bar (app/bundle.js:17:10)",
+        "    at track (http://thirdparty.app/script.js:1:530)",
+        "    at app/bundle.js:21:10"
+      ])
+    })
+
+    it("cleans Safari/FF-style backtraces", () => {
+      const error = new Error("test error")
+      error.stack = [
+        "Foo@http://localhost:8080/assets/app/bundle.js:13:10",
+        "Bar@http://localhost:8080/assets/app/bundle.js:17:10",
+        "track@http://thirdparty.app/script.js:1:530",
+        "@http://localhost:8080/assets/app/bundle.js:21:10"
+      ].join("\n")
+
+      span.setError(error)
+      span.cleanBacktracePath(new RegExp("/assets/(app/.*)$"))
+
+      const backtrace = span.serialize().error.backtrace
+      expect(backtrace).toEqual([
+        "Foo@app/bundle.js:13:10",
+        "Bar@app/bundle.js:17:10",
+        "track@http://thirdparty.app/script.js:1:530",
+        "@app/bundle.js:21:10"
+      ])
+    })
+
+    it("tries matchers in order", () => {
+      const error = new Error("test error")
+      error.stack = [
+        "Foo@http://localhost:8080/assets/app/bundle.js:13:10",
+        "Bar@http://cdn.coolbeans.app/assets/9ac54f82103a399d/app/bundle.js:17:10"
+      ].join("\n")
+
+      span.setError(error)
+      span.cleanBacktracePath([
+        // This can only match `Bar`.
+        new RegExp("/assets/[0-9a-f]{16}/(.*)$"),
+
+        // This can match both `Foo` and `Bar`, but should only
+        // match `Foo` because the previous matcher takes precedence.
+        new RegExp("/assets/(.*)$")
+      ])
+
+      const backtrace = span.serialize().error.backtrace
+      expect(backtrace).toEqual([
+        "Foo@app/bundle.js:13:10",
+        "Bar@app/bundle.js:17:10"
+      ])
+    })
+  })
 })

--- a/packages/javascript/src/index.ts
+++ b/packages/javascript/src/index.ts
@@ -50,7 +50,9 @@ export default class Appsignal implements JSClient {
 
     // starting with no key means nothing will be sent to the API
     if (key === "") {
-      console.info("[APPSIGNAL]: Started in development mode.")
+      console.info(
+        "[APPSIGNAL]: No API key provided. Started in development mode."
+      )
     }
 
     this._api = new PushApi({

--- a/packages/javascript/src/index.ts
+++ b/packages/javascript/src/index.ts
@@ -51,7 +51,7 @@ export default class Appsignal implements JSClient {
     // starting with no key means nothing will be sent to the API
     if (key === "") {
       console.info(
-        "[APPSIGNAL]: No API key provided. Started in development mode."
+        "[APPSIGNAL]: No API key provided. Started in development mode. No data will be sent."
       )
     }
 
@@ -155,8 +155,6 @@ export default class Appsignal implements JSClient {
       if (error instanceof Span) {
         const serializedError = error.serialize().error
 
-        // using the bang operator here as tsc doesnt recognise that we are
-        // checking for the value to be set as the first predicate
         if (
           serializedError.message &&
           this.ignored.some(el => el.test(serializedError.message!))
@@ -207,6 +205,10 @@ export default class Appsignal implements JSClient {
     // as arguments is added
     if (this._hooks.overrides.length > 0) {
       compose(...this._hooks.overrides)(span)
+    }
+
+    if (this._options.matchPath) {
+      span.cleanBacktracePath(this._options.matchPath)
     }
 
     if (Environment.supportsPromises()) {

--- a/packages/javascript/src/interfaces/options.ts
+++ b/packages/javascript/src/interfaces/options.ts
@@ -7,6 +7,7 @@ export interface AppsignalOptions extends BaseOptions {
   namespace?: string
   revision?: string
   ignoreErrors?: RegExp[]
+  matchPath?: RegExp | RegExp[]
 }
 
 export interface PushApiOptions extends BaseOptions {

--- a/packages/javascript/src/span.ts
+++ b/packages/javascript/src/span.ts
@@ -69,4 +69,87 @@ export class Span extends Serializable<JSSpanData> {
     this._data.breadcrumbs = breadcrumbs
     return this
   }
+
+  // @private
+  // Do not use this function directly. Instead, set the `matchPath`
+  // configuration option when initializing AppSignal.
+  public cleanBacktracePath(matchPath: RegExp | RegExp[]): this {
+    if (matchPath instanceof RegExp) {
+      matchPath = [matchPath]
+    }
+
+    if (!Array.isArray(matchPath)) {
+      return this
+    }
+
+    if (!this._data.error || !this._data.error.backtrace) {
+      return this
+    }
+
+    this._data.error.backtrace = this._data.error.backtrace.map(line => {
+      const path = extractPath(line)
+      if (!path) {
+        return line
+      }
+
+      for (const matcher of matchPath as RegExp[]) {
+        if (!(matcher instanceof RegExp)) {
+          continue
+        }
+
+        const match = path.match(matcher)
+        if (!match) {
+          continue
+        }
+
+        const relevantPath = match[1]
+        if (relevantPath) {
+          return line.replace(path, match[1])
+        }
+      }
+
+      return line
+    })
+
+    return this
+  }
+}
+
+// Backtrace formats are different between browsers, and generally not
+// meant to be parsed by machines. This function does a best-effort to
+// extract whatever is at the location in the line where the path
+// usually appears.
+//
+// If it returns `undefined`, it means that it could not find where the
+// path is located in the backtrace line. If it returns a string, that
+// string _may_ be a path, but it may contain non-path elements as well.
+function extractPath(backtraceLine: string): string | undefined {
+  // A Chrome backtrace line always contains `at` near the beginning,
+  // preceded by space characters and followed by one space.
+  const IS_CHROME = /^\s*at\s/
+  // In a Chrome backtrace line, the path (if it is available)
+  // is located, usually within parentheses, after the "@" towards the
+  // end of the line, along with the line number and column number,
+  // separated by colons. We check for those to reject clear non-paths.
+  const CHROME_PATH = /at(?:\s.*)?\s\(?(.*):\d*:\d*\)?$/i
+
+  if (backtraceLine.match(IS_CHROME)) {
+    const match = backtraceLine.match(CHROME_PATH)
+    return match ? match[1] : undefined
+  }
+
+  // A Safari or Firefox backtrace line always contains `@` after the first
+  // term in the line.
+  const IS_SAFARI_FF = /^.*@/
+
+  // In a Safari or Firefox backtrace line, the path (if it is available)
+  // is located after the "@" at the towards end of the line, followed by
+  // the line number and column number, separated by colons. We check for
+  // those to reject clear non-paths.
+  const SAFARI_FF_PATH = /@\s?(.*):\d*:\d*$/i
+
+  if (backtraceLine.match(IS_SAFARI_FF)) {
+    const match = backtraceLine.match(SAFARI_FF_PATH)
+    return match ? match[1] : undefined
+  }
 }

--- a/packages/javascript/src/span.ts
+++ b/packages/javascript/src/span.ts
@@ -98,13 +98,13 @@ export class Span extends Serializable<JSSpanData> {
         }
 
         const match = path.match(matcher)
-        if (!match) {
+        if (!match || match.length < 2) {
           continue
         }
 
-        const relevantPath = match[1]
+        const relevantPath = match.slice(1).join("")
         if (relevantPath) {
-          return line.replace(path, match[1])
+          return line.replace(path, relevantPath)
         }
       }
 


### PR DESCRIPTION
**Feedback please!** 🙏  This could be merged as-is, in the sense that it does work, but it's very much a half-baked proposal. Do we want this functionality to exist at all? How can we make it less of a footgun? Do we like the naming? I don't like the naming.

---

This PR implements a `matchPath` configuration option for customers to match the relevant part of a backtrace line path. This is similar to what the `app_path` configuration option does automatically in our back-end integrations, but it's done manually by the customer.

This provides a workaround for customers whose asset deployment paths are not fully predictable -- for example, customers who develop Electron or React Native applications, or customers who deploy their assets to auto-generated subdomain names.

This is a somewhat recurring support request -- we could find more on Intercom, because customers with unusual sourcemap requirements tend to run into multiple sourcemap issues, so their implicit feature requests aren't always logged as such -- but, going by Github alone: https://github.com/appsignal/feature-requests/issues/90, https://github.com/appsignal/feature-requests/issues/22

For those customers, it is currently not possible to use private sourcemaps, as the name to match those sourcemaps is not known in advance, and backtrace line error grouping does not work correctly, as said backtrace lines are not consistent between deployments or environments.

**Using this workaround means that public sourcemap detection will no longer work for this application.** In order for sourcemaps to work, customers using `matchPath` will need to upload their sourcemaps to the private sourcemap API.