### PR TITLE
Set action by default in stimulus integration

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -139,6 +139,18 @@ blocks:
       commands:
       - script/install_packages react@17.0.2 react-dom@17.0.2 @testing-library/react@11.1.2
       - mono test --package=@appsignal/react
+    - name: "@appsignal/stimulus - stimulus@latest"
+      commands:
+      - script/install_packages stimulus@latest
+      - mono test --package=@appsignal/stimulus
+    - name: "@appsignal/stimulus - stimulus@3.0.1"
+      commands:
+      - script/install_packages stimulus@3.0.1
+      - mono test --package=@appsignal/stimulus
+    - name: "@appsignal/stimulus - stimulus@2.0.0"
+      commands:
+      - script/install_packages stimulus@2.0.0
+      - mono test --package=@appsignal/stimulus
     - name: "@appsignal/vue - vue@latest"
       commands:
       - script/install_packages vue@latest

--- a/packages/stimulus/.changesets/add-action-to-stimulus.md
+++ b/packages/stimulus/.changesets/add-action-to-stimulus.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Add a default action to the stimulus error handler, based on the current controller.

--- a/packages/stimulus/src/__tests__/index.test.ts
+++ b/packages/stimulus/src/__tests__/index.test.ts
@@ -26,16 +26,19 @@ describe("Stimulus errorHandler", () => {
   it("calls AppSignal helper methods", () => {
     const err = new Error("test")
     const message = "This is a test message"
+    const detail = { identifier: "foo" }
 
     const stimulusApplication: any = {}
 
     installErrorHandler(appsignal, stimulusApplication)
 
-    stimulusApplication.handleError(err, message)
+    stimulusApplication.handleError(err, message, detail)
+
+    expect(mock.setAction).toBeCalledWith("foo-controller")
 
     expect(mock.setTags).toBeCalledWith({
       framework: "Stimulus",
-      message,
+      message
     })
 
     expect(mock.setError).toBeCalledWith(err)
@@ -46,15 +49,16 @@ describe("Stimulus errorHandler", () => {
   it("calls any previously defined error handler", () => {
     const err = new Error("test")
     const message = "This is a test message"
+    const detail = { identifier: "foo" }
 
     const originalErrorHandler = jest.fn()
     const stimulusApplication: any = { handleError: originalErrorHandler }
 
     installErrorHandler(appsignal, stimulusApplication)
 
-    stimulusApplication.handleError(err, message)
+    stimulusApplication.handleError(err, message, detail)
 
     expect(appsignal.send).toBeCalled()
-    expect(originalErrorHandler).toBeCalledWith(err, message)
+    expect(originalErrorHandler).toBeCalledWith(err, message, detail)
   })
 })

--- a/packages/stimulus/src/__tests__/index.test.ts
+++ b/packages/stimulus/src/__tests__/index.test.ts
@@ -1,0 +1,60 @@
+import { installErrorHandler } from "../index"
+import type { JSSpan } from "@appsignal/types"
+
+describe("Stimulus errorHandler", () => {
+  let appsignal: any
+
+  const mock: any = {
+    setAction: jest.fn(() => mock),
+    setError: jest.fn(() => mock),
+    setTags: jest.fn(() => mock)
+  }
+
+  const SpanMock = jest.fn().mockImplementation(() => mock)
+
+  beforeEach(() => {
+    appsignal = {
+      createSpan: (fn: (span: JSSpan) => void) => {
+        const mock = new SpanMock()
+        fn(mock)
+        return mock
+      },
+      send: jest.fn()
+    }
+  })
+
+  it("calls AppSignal helper methods", () => {
+    const err = new Error("test")
+    const message = "This is a test message"
+
+    const stimulusApplication: any = {}
+
+    installErrorHandler(appsignal, stimulusApplication)
+
+    stimulusApplication.handleError(err, message)
+
+    expect(mock.setTags).toBeCalledWith({
+      framework: "Stimulus",
+      message,
+    })
+
+    expect(mock.setError).toBeCalledWith(err)
+
+    expect(appsignal.send).toBeCalled()
+  })
+
+  it("calls any previously defined error handler", () => {
+    const err = new Error("test")
+    const message = "This is a test message"
+
+    const originalErrorHandler = jest.fn()
+    const stimulusApplication: any = { handleError: originalErrorHandler }
+
+    installErrorHandler(appsignal, stimulusApplication)
+
+    stimulusApplication.handleError(err, message)
+
+    expect(appsignal.send).toBeCalled()
+    expect(originalErrorHandler).toBeCalledWith(err, message)
+  })
+})

--- a/packages/stimulus/src/index.ts
+++ b/packages/stimulus/src/index.ts
@@ -3,9 +3,16 @@ import type { JSClient, JSSpan } from "@appsignal/types"
 export function installErrorHandler(appsignal: JSClient, application: any) {
   const prevHandler = application.handleError
 
-  application.handleError = function (error: Error, message: string) {
+  application.handleError = function (
+    error: Error,
+    message: string,
+    detail: { identifier: string }
+  ) {
     const span = appsignal.createSpan((span: JSSpan) =>
-      span.setTags({ framework: "Stimulus", message }).setError(error)
+      span
+        .setAction(`${detail.identifier}-controller`)
+        .setTags({ framework: "Stimulus", message })
+        .setError(error)
     )
 
     appsignal.send(span)

--- a/packages/stimulus/src/index.ts
+++ b/packages/stimulus/src/index.ts
@@ -6,11 +6,11 @@ export function installErrorHandler(appsignal: JSClient, application: any) {
   application.handleError = function (
     error: Error,
     message: string,
-    detail: { identifier: string }
+    detail: { identifier?: string }
   ) {
     const span = appsignal.createSpan((span: JSSpan) =>
       span
-        .setAction(`${detail.identifier}-controller`)
+        .setAction(detail?.identifier || "[unknown Stimulus controller]")
         .setTags({ framework: "Stimulus", message })
         .setError(error)
     )


### PR DESCRIPTION
## what

This updates the default error handler for the stimulus integration to call `setAction` using the name of the stimulus controller where the error was thrown.

I also included some tests for the stimulus integration, since there were none yet.

## why

We've been using `@appsignal/stimulus` for our frontend exception tracking for a while and it's working great, except that all errors end up being grouped together which caused some confusion.

<img width="185" alt="Screenshot 2024-12-17 at 15 01 03" src="https://github.com/user-attachments/assets/2ea9a105-f9d8-405f-b20c-5145f5983fc5" />

We've already started using this same idea at [Bento](https://github.com/bentohq) by writing our own custom error handler. This results in grouping errors by controller, which is similar to how errors are grouped by default for Ruby on Rails backend web requests.

<img width="328" alt="Screenshot 2024-12-17 at 15 04 17" src="https://github.com/user-attachments/assets/157046b7-48d2-4fcf-9d70-d4db58d75f19" />

## notes

Apologies if this is the wrong direction. I didn't create an issue before implementing this pull-request based on one of the tasks from #613, which seems to have broad approval:

> Report the action in which an error takes place (for example, for a React component, attempt to report the component name)

This is also similar to [how it's done for vue](https://github.com/appsignal/appsignal-javascript/blob/ef1265730fe1eef2dbd52bc71027d3ae90a744b6/packages/vue/src/index.ts#L14), which is in place even after #41.

### safety

Based on the code that calls the error handler, it looks like there should always be details with an identifier. This code has been in place since stimulus v1.0.0-beta1.

https://github.com/hotwired/stimulus/blob/1c425edb7d71b05ee85e76becdd1620988042de2/packages/%40stimulus/core/src/context.ts#L117-L119

If there's a strong opinion, I'd be happy to make this more defensive, but I don't think it's necessary.
