### PR TITLE
Support React 19

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -127,6 +127,10 @@ blocks:
       commands:
       - script/install_packages react@latest react-dom@latest
       - mono test --package=@appsignal/react
+    - name: "@appsignal/react - react@19.0.0"
+      commands:
+      - script/install_packages react@19.0.0 react-dom@19.0.0
+      - mono test --package=@appsignal/react
     - name: "@appsignal/react - react@18.2.0"
       commands:
       - script/install_packages react@18.2.0 react-dom@18.2.0

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -129,6 +129,10 @@ matrix:
           packages:
             react: "latest"
             react-dom: "latest"
+        - name: "react@19.0.0"
+          packages:
+            react: "19.0.0"
+            react-dom: "19.0.0"
         - name: "react@18.2.0"
           packages:
             react: "18.2.0"

--- a/packages/react/.changesets/add-support-for-react-19.md
+++ b/packages/react/.changesets/add-support-for-react-19.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Add support for React 19

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -26,7 +26,7 @@
     "@appsignal/core": "=1.1.24"
   },
   "peerDependencies": {
-    "react": ">= 16.8.6 < 19"
+    "react": ">= 16.8.6 < 20"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Fixes #647. See https://github.com/appsignal/frontend-test-setups/pull/41 for test setup.

### [Add React 19 to CI build matrix](https://github.com/appsignal/appsignal-javascript/commit/fa55399cb9cd293628b91470c7a2f90169e38a74)

Test against React 19 on CI, same way it is done against other
React versions.

### [Update React peer dependency to allow 19.x](https://github.com/appsignal/appsignal-javascript/commit/30bf30b30dde75b357c066c3228d2e0e9d388e17)

Allow the `@appsignal/react` package to be used alongside any
React version with 19 as its major number.