### PR TITLE
Update axios dependency to ^1.8.2

### DIFF
--- a/packages/webpack/.changesets/update-axios-dependency-to-1-8-2-or-higher.md
+++ b/packages/webpack/.changesets/update-axios-dependency-to-1-8-2-or-higher.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: security
+---
+
+Update the axios dependency to 1.8.2 or higher. This fixes CVE-2024-39338.

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -28,7 +28,7 @@
     "access": "public"
   },
   "dependencies": {
-    "axios": "^0.28.0",
+    "axios": "^1.8.2",
     "form-data": "^4.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1336,12 +1336,12 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-axios@^0.28.0:
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.28.0.tgz#801a4d991d0404961bccef46800e1170f8278c89"
-  integrity sha512-Tu7NYoGY4Yoc7I+Npf9HhUMtEEpV7ZiLH9yndTCoNhcpBH0kwcvFbzYN9/u5QKI5A6uefjsNNWaz5olJVYS62Q==
+axios@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.8.2.tgz#fabe06e241dfe83071d4edfbcaa7b1c3a40f7979"
+  integrity sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==
   dependencies:
-    follow-redirects "^1.15.0"
+    follow-redirects "^1.15.6"
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
@@ -2312,10 +2312,10 @@ find-versions@^4.0.0:
   dependencies:
     semver-regex "^3.1.2"
 
-follow-redirects@^1.15.0:
-  version "1.15.6"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
-  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
+follow-redirects@^1.15.6:
+  version "1.15.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
+  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
 
 for-each@^0.3.3:
   version "0.3.3"


### PR DESCRIPTION
Version 1.8.2 contains a fix for CVE-2024-39338.

No API changes seem to be needed on our end.

![2025-03-11 at 11 31 33 - axios Requests Vulnerable To Possible SSRF and Credential Leakage via Absolute URL · Dependabot alert #48 · appsignalappsignal-javascript](https://github.com/user-attachments/assets/72a03867-c188-4d02-a873-307bd1ccf26d)
