### PR TITLE
Handle RangeError in JSON serialisation

### DIFF
--- a/packages/plugin-breadcrumbs-console/.changesets/handle-rangeerror-on-json-serialisation.md
+++ b/packages/plugin-breadcrumbs-console/.changesets/handle-rangeerror-on-json-serialisation.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Handle RangeError on JSON serialisation. When failing to serialise a value that is too big, catch the error and replace the value with a description of the error. This prevents an infinite loop where attempting to send a span raises an error, which is caught by the window event plugin, which attempts to send a span, raising another error.

--- a/packages/plugin-breadcrumbs-console/src/index.ts
+++ b/packages/plugin-breadcrumbs-console/src/index.ts
@@ -52,7 +52,16 @@ function serializeValue(value: any, method: string) {
     case "undefined":
       return "undefined"
     default:
-      return JSON.stringify(value, circularReplacer())
+      try {
+        return JSON.stringify(value, circularReplacer())
+      } catch (e) {
+        // Stringifying the value may cause a RangeError when the reason
+        // is a very large object.
+        if (e && typeof (e as any).message === "string") {
+          return `[could not stringify value: ${(e as any).message}]`
+        }
+        return "[could not stringify value]"
+      }
   }
 }
 

--- a/packages/plugin-window-events/.changesets/handle-rangeerror-on-json-serialisation.md
+++ b/packages/plugin-window-events/.changesets/handle-rangeerror-on-json-serialisation.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Handle RangeError on JSON serialisation. When failing to serialise a value that is too big, catch the error and replace the value with a description of the error. This prevents an infinite loop where attempting to send a span raises an error, which is caught by the window event plugin, which attempts to send a span, raising another error.

--- a/packages/plugin-window-events/src/index.ts
+++ b/packages/plugin-window-events/src/index.ts
@@ -108,7 +108,16 @@ function windowEventsPlugin(options?: { [key: string]: any }) {
       return event.reason
     }
 
-    return JSON.stringify(event.reason, circularReplacer())
+    try {
+      return JSON.stringify(event.reason, circularReplacer())
+    } catch (e) {
+      // Stringifying the reason may cause a RangeError when the reason
+      // is a very large object.
+      if (e && typeof (e as any).message === "string") {
+        return `[could not stringify value: ${(e as any).message}]`
+      }
+      return "[could not stringify value]"
+    }
   }
 
   function circularReplacer() {


### PR DESCRIPTION
When calling `JSON.stringify`, expect an error to be raised due to the resulting value being too large. Handle it to prevent it being an uncaught error, which could cause a loop.

Fixes #653.