### PR TITLE
Allow functions as backtrace matchers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12066,10 +12066,10 @@
     },
     "packages/angular": {
       "name": "@appsignal/angular",
-      "version": "1.0.16",
+      "version": "1.0.17",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/javascript": "=1.5.0"
+        "@appsignal/javascript": "=1.6.0"
       },
       "peerDependencies": {
         "@angular/core": ">= 8.0.0"
@@ -12091,10 +12091,10 @@
     },
     "packages/ember": {
       "name": "@appsignal/ember",
-      "version": "1.0.16",
+      "version": "1.0.17",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/javascript": "=1.5.0"
+        "@appsignal/javascript": "=1.6.0"
       },
       "peerDependencies": {
         "ember-source": ">= 3.11.1"
@@ -12102,7 +12102,7 @@
     },
     "packages/javascript": {
       "name": "@appsignal/javascript",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -12110,42 +12110,42 @@
     },
     "packages/plugin-breadcrumbs-console": {
       "name": "@appsignal/plugin-breadcrumbs-console",
-      "version": "1.1.35",
+      "version": "1.1.36",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/javascript": "=1.5.0"
+        "@appsignal/javascript": "=1.6.0"
       }
     },
     "packages/plugin-breadcrumbs-network": {
       "name": "@appsignal/plugin-breadcrumbs-network",
-      "version": "1.1.22",
+      "version": "1.1.23",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/javascript": "=1.5.0"
+        "@appsignal/javascript": "=1.6.0"
       }
     },
     "packages/plugin-path-decorator": {
       "name": "@appsignal/plugin-path-decorator",
-      "version": "1.0.16",
+      "version": "1.0.17",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/javascript": "=1.5.0"
+        "@appsignal/javascript": "=1.6.0"
       }
     },
     "packages/plugin-window-events": {
       "name": "@appsignal/plugin-window-events",
-      "version": "1.0.24",
+      "version": "1.0.25",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/javascript": "=1.5.0"
+        "@appsignal/javascript": "=1.6.0"
       }
     },
     "packages/preact": {
       "name": "@appsignal/preact",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/javascript": "=1.5.0"
+        "@appsignal/javascript": "=1.6.0"
       },
       "peerDependencies": {
         "preact": "^10.0.0"
@@ -12153,10 +12153,10 @@
     },
     "packages/react": {
       "name": "@appsignal/react",
-      "version": "1.0.29",
+      "version": "1.0.30",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/javascript": "=1.5.0"
+        "@appsignal/javascript": "=1.6.0"
       },
       "peerDependencies": {
         "react": ">= 16.8.6 < 20"
@@ -12164,10 +12164,10 @@
     },
     "packages/stimulus": {
       "name": "@appsignal/stimulus",
-      "version": "1.0.19",
+      "version": "1.0.20",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/javascript": "=1.5.0"
+        "@appsignal/javascript": "=1.6.0"
       },
       "peerDependencies": {
         "@hotwired/stimulus": "^3.0",
@@ -12184,10 +12184,10 @@
     },
     "packages/vue": {
       "name": "@appsignal/vue",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "MIT",
       "dependencies": {
-        "@appsignal/javascript": "=1.5.0"
+        "@appsignal/javascript": "=1.6.0"
       },
       "peerDependencies": {
         "vue": ">= 2.6.0"
@@ -12195,7 +12195,7 @@
     },
     "packages/webpack": {
       "name": "@appsignal/webpack",
-      "version": "1.1.6",
+      "version": "1.1.7",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.2",

--- a/packages/javascript/.changesets/allow-functions-as-backtrace-matchers.md
+++ b/packages/javascript/.changesets/allow-functions-as-backtrace-matchers.md
@@ -1,0 +1,19 @@
+---
+bump: patch
+type: add
+---
+
+Allow functions as backtrace matchers. Alongside regular expressions, you can also provide custom functions to match and replace paths in the backtrace:
+
+```javascript
+const appsignal = new Appsignal({
+  // ...
+  matchBacktracePaths: [(path) => {
+    if (path.indexOf("/bundle/") !== -1) {
+      return "bundle.js"
+    }
+  }]
+})
+```
+
+The function must take a backtrace line path as an argument. When the function returns a non-empty string, the string will be used as the path for that backtrace line. Otherwise, the path will be left unchanged.

--- a/packages/javascript/src/options.ts
+++ b/packages/javascript/src/options.ts
@@ -3,11 +3,16 @@ interface BaseOptions {
   uri?: string
 }
 
+export type BacktraceMatcher = (path: string) => string | undefined
+
 export interface AppsignalOptions extends BaseOptions {
   namespace?: string
   revision?: string
   ignoreErrors?: RegExp[]
-  matchBacktracePaths?: RegExp | RegExp[]
+  matchBacktracePaths?:
+    | RegExp
+    | BacktraceMatcher
+    | (RegExp | BacktraceMatcher)[]
 }
 
 export interface PushApiOptions extends BaseOptions {


### PR DESCRIPTION
Allow the customer to provide a custom function as a path backtrace matcher. The function takes the backtrace line path as an argument. If the function returns a non-empty string, the path in the backtrace line is replaced with the return value.