### PR TITLE
Add urql integration package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,21 @@
         "webpack": "^5.76.0"
       }
     },
+    "node_modules/@0no-co/graphql.web": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.2.0.tgz",
+      "integrity": "sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
       "license": "Apache-2.0",
@@ -101,6 +116,10 @@
     },
     "node_modules/@appsignal/stimulus": {
       "resolved": "packages/stimulus",
+      "link": true
+    },
+    "node_modules/@appsignal/urql": {
+      "resolved": "packages/urql",
       "link": true
     },
     "node_modules/@appsignal/vue": {
@@ -3094,6 +3113,17 @@
       "version": "21.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@urql/core": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@urql/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-/n0ieD0mvvDnVAXEQgX/7qJiVcvYvNkOHeBvkwtylfjydar123caCXcl58PXFY11oU1oquJocVXHxLAbtv4x1A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@0no-co/graphql.web": "^1.0.13",
+        "wonka": "^6.3.2"
+      }
     },
     "node_modules/@vue/compiler-core": {
       "version": "3.2.33",
@@ -11629,6 +11659,21 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/urql": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/urql/-/urql-4.2.2.tgz",
+      "integrity": "sha512-3GgqNa6iF7bC4hY/ImJKN4REQILcSU9VKcKL8gfELZM8mM5BnLH1BsCc8kBdnVGD1LIFOs4W3O2idNHhON1r0w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@urql/core": "^5.1.1",
+        "wonka": "^6.3.2"
+      },
+      "peerDependencies": {
+        "@urql/core": "^5.0.0",
+        "react": ">= 16.8.0"
+      }
+    },
     "node_modules/use": {
       "version": "3.1.1",
       "dev": true,
@@ -11931,6 +11976,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/wonka": {
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.6.tgz",
+      "integrity": "sha512-MXH+6mDHAZ2GuMpgKS055FR6v0xVP3XwquxIMYXgiW+FejHQlMGlvVRZT4qMCxR+bEo/FCtIdKxwej9WV3YQag==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/word-wrap": {
       "version": "1.2.4",
       "dev": true,
@@ -12181,6 +12233,18 @@
         "stimulus": {
           "optional": true
         }
+      }
+    },
+    "packages/urql": {
+      "name": "@appsignal/urql",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@appsignal/javascript": "=1.6.1"
+      },
+      "peerDependencies": {
+        "urql": ">= 2.0.0 < 5",
+        "wonka": ">= 4.0.0 < 7"
       }
     },
     "packages/vue": {

--- a/packages/urql/.changesets/add-urql-integration-package.md
+++ b/packages/urql/.changesets/add-urql-integration-package.md
@@ -1,0 +1,21 @@
+---
+bump: major
+type: add
+---
+
+Our new `@appsignal/urql` package allows reporting all GraphQL errors automatically through a custom `urql` exchange:
+
+```javascript
+import { createClient, fetchExchange } from 'urql';
+import Appsignal from '@appsignal/javascript';
+import { createAppsignalExchange } from '@appsignal/urql';
+
+const appsignal = new Appsignal({
+  key: 'YOUR FRONTEND API KEY'
+});
+
+const client = createClient({
+  url: 'https://api.example.com/graphql',
+  exchanges: [createAppsignalExchange(appsignal), fetchExchange]
+});
+```

--- a/packages/urql/README.md
+++ b/packages/urql/README.md
@@ -1,0 +1,115 @@
+# `@appsignal/urql`
+
+- [AppSignal.com website][appsignal]
+- [Documentation][docs]
+- [Support][contact]
+
+The `@appsignal/javascript` integration for urql GraphQL client.
+
+See also the [mono repo README](../../README.md) for more information.
+
+## Installation
+
+Add the  `@appsignal/urql` and `@appsignal/javascript` packages to your `package.json`. Then, run `yarn install`/`npm install`.
+
+You can also add these packages to your `package.json` on the command line:
+
+```
+yarn add @appsignal/javascript @appsignal/urql urql wonka
+npm install --save @appsignal/javascript @appsignal/urql urql wonka
+```
+
+## Usage
+
+### Urql Exchange
+
+The `@appsignal/urql` package provides a custom urql exchange that automatically reports GraphQL errors to AppSignal. This exchange intercepts all query and mutation results and reports any errors without requiring changes to individual `useQuery` calls.
+
+```typescript
+import { createClient, fetchExchange } from 'urql';
+import Appsignal from '@appsignal/javascript';
+import { createAppsignalExchange } from '@appsignal/urql';
+
+const appsignal = new Appsignal({
+  key: 'YOUR FRONTEND API KEY'
+});
+
+const client = createClient({
+  url: 'https://api.example.com/graphql',
+  exchanges: [createAppsignalExchange(appsignal), fetchExchange]
+});
+```
+
+The exchange will automatically:
+- Report all GraphQL errors to AppSignal
+- Include the GraphQL query body as a parameter (visible in AppSignal's error details)
+- Include the endpoint URL as a tag
+- Include operation name and type as tags (when available)
+
+### Error Details
+
+When a GraphQL error occurs, AppSignal will receive:
+
+- **Error message**: A concatenation of all GraphQL error messages
+- **Tags**:
+  - `endpoint`: The GraphQL endpoint URL
+  - `operationName`: The name of the GraphQL operation (if specified)
+  - `operationType`: The type of operation (query, mutation, subscription)
+- **Parameters**:
+  - `query`: The full GraphQL query body
+
+This provides complete context for debugging GraphQL errors in your application.
+
+## Development
+
+### Installation
+
+Make sure mono is installed and bootstrapped, see the [project README's development section](../../README.md#dev-install) for more information.
+
+You can then run the following to start the compiler in _watch_ mode. This automatically compiles both the ES Module and CommonJS variants:
+
+```bash
+yarn build:watch
+```
+
+You can also build the library without watching the directory:
+
+```
+yarn build        # build both CJS and ESM
+yarn build:cjs    # just CJS
+yarn build:esm    # just ESM
+```
+
+### Testing
+
+The tests for this library use [Jest](https://jestjs.io) as the test runner. Once you've installed the dependencies, you can run the following command in the root of this repository to run the tests for all packages, or in the directory of a package to run only the tests pertaining to that package:
+
+```bash
+yarn test
+```
+
+### Versioning
+
+This repo uses [Semantic Versioning][semver] (often referred to as _semver_). Each package in the repository is versioned independently from one another.
+
+## Contributing
+
+Thinking of contributing to this repo? Awesome! 🚀
+
+Please follow our [Contributing guide][contributing-guide] in our documentation and follow our [Code of Conduct][coc].
+
+Also, we would be very happy to send you Stroopwafles. Have look at everyone we send a package to so far on our [Stroopwafles page][waffles-page].
+
+## Support
+
+[Contact us][contact] and speak directly with the engineers working on AppSignal. They will help you get set up, tweak your code and make sure you get the most out of using AppSignal.
+
+[appsignal]: https://appsignal.com
+[appsignal-sign-up]: https://appsignal.com/users/sign_up
+[contact]: mailto:support@appsignal.com
+[coc]: https://docs.appsignal.com/appsignal/code-of-conduct.html
+[waffles-page]: https://appsignal.com/waffles
+[docs]: http://docs.appsignal.com
+[contributing-guide]: http://docs.appsignal.com/appsignal/contributing.html
+
+[semver]: http://semver.org/

--- a/packages/urql/jest.config.js
+++ b/packages/urql/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "jsdom",
+  roots: ["<rootDir>/src"],
+  transform: {
+    "^.+\\.tsx?$": "ts-jest"
+  }
+}

--- a/packages/urql/package.json
+++ b/packages/urql/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@appsignal/urql",
+  "version": "1.0.0",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/appsignal/appsignal-javascript.git",
+    "directory": "packages/urql"
+  },
+  "license": "MIT",
+  "scripts": {
+    "build": "npm run build:cjs && npm run build:esm",
+    "build:esm": "tsc -p tsconfig.esm.json",
+    "build:esm:watch": "tsc -p tsconfig.esm.json -w --preserveWatchOutput",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:cjs:watch": "tsc -p tsconfig.cjs.json -w --preserveWatchOutput",
+    "build:watch": "run-p build:cjs:watch build:esm:watch",
+    "clean": "rimraf dist coverage",
+    "link:npm": "npm link",
+    "test": "jest --passWithNoTests",
+    "test:watch": "jest --watch"
+  },
+  "dependencies": {
+    "@appsignal/javascript": "=1.6.1"
+  },
+  "peerDependencies": {
+    "urql": ">= 2.0.0 < 5",
+    "wonka": ">= 4.0.0 < 7"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/urql/src/__tests__/index.test.ts
+++ b/packages/urql/src/__tests__/index.test.ts
@@ -10,7 +10,6 @@ describe("reportGraphQLError", () => {
       },
       operation: {
         query: { loc: { source: { body: "query { post { id } }" } } },
-        operationName: "GetPost",
         kind: "query"
       }
     }
@@ -27,7 +26,6 @@ describe("reportGraphQLError", () => {
     expect(span.setTags).toHaveBeenCalledWith({
       endpoint: "https://example.com/graphql"
     })
-    expect(span.setTags).toHaveBeenCalledWith({ operationName: "GetPost" })
     expect(span.setTags).toHaveBeenCalledWith({ operationType: "query" })
     expect(span.setParams).toHaveBeenCalledWith({
       query: "query { post { id } }"
@@ -64,20 +62,6 @@ describe("reportGraphQLError", () => {
 
     expect(span.setParams).toHaveBeenCalledWith({
       query: "mutation { createPost { id } }"
-    })
-  })
-
-  it("sets operationName tag on the span", () => {
-    const { appsignal, span } = createMockAppsignal()
-    const result = {
-      error: { message: "Something went wrong" },
-      operation: { operationName: "CreatePost" }
-    }
-
-    reportGraphQLError(result, appsignal, {})
-
-    expect(span.setTags).toHaveBeenCalledWith({
-      operationName: "CreatePost"
     })
   })
 

--- a/packages/urql/src/__tests__/index.test.ts
+++ b/packages/urql/src/__tests__/index.test.ts
@@ -1,0 +1,108 @@
+import { reportGraphQLError } from "../index"
+
+describe("reportGraphQLError", () => {
+  it("reports a GraphQL error to AppSignal with all metadata", () => {
+    const { appsignal, span } = createMockAppsignal()
+    const client = { url: "https://example.com/graphql" }
+    const result = {
+      error: {
+        graphQLErrors: [{ message: "Not found" }]
+      },
+      operation: {
+        query: { loc: { source: { body: "query { post { id } }" } } },
+        operationName: "GetPost",
+        kind: "query"
+      }
+    }
+
+    reportGraphQLError(result, appsignal, client)
+
+    expect(appsignal.sendError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "GraphQLError",
+        message: "GraphQL Error: Not found"
+      }),
+      expect.any(Function)
+    )
+    expect(span.setTags).toHaveBeenCalledWith({
+      endpoint: "https://example.com/graphql"
+    })
+    expect(span.setTags).toHaveBeenCalledWith({ operationName: "GetPost" })
+    expect(span.setTags).toHaveBeenCalledWith({ operationType: "query" })
+    expect(span.setParams).toHaveBeenCalledWith({
+      query: "query { post { id } }"
+    })
+  })
+
+  it("sets endpoint tag", () => {
+    const { appsignal, span } = createMockAppsignal()
+    const result = {
+      error: { message: "Something went wrong" },
+      operation: {
+        query: { loc: { source: { body: "mutation { createUser { id } }" } } }
+      }
+    }
+
+    const client = { url: "https://example.com/graphql" }
+    reportGraphQLError(result, appsignal, client)
+
+    expect(span.setTags).toHaveBeenCalledWith({
+      endpoint: "https://example.com/graphql"
+    })
+  })
+
+  it("sets query params on the span", () => {
+    const { appsignal, span } = createMockAppsignal()
+    const result = {
+      error: { message: "Something went wrong" },
+      operation: {
+        query: { loc: { source: { body: "mutation { createPost { id } }" } } }
+      }
+    }
+
+    reportGraphQLError(result, appsignal, {})
+
+    expect(span.setParams).toHaveBeenCalledWith({
+      query: "mutation { createPost { id } }"
+    })
+  })
+
+  it("sets operationName tag on the span", () => {
+    const { appsignal, span } = createMockAppsignal()
+    const result = {
+      error: { message: "Something went wrong" },
+      operation: { operationName: "CreatePost" }
+    }
+
+    reportGraphQLError(result, appsignal, {})
+
+    expect(span.setTags).toHaveBeenCalledWith({
+      operationName: "CreatePost"
+    })
+  })
+
+  it("sets operationType tag on the span", () => {
+    const { appsignal, span } = createMockAppsignal()
+    const result = {
+      error: { message: "Something went wrong" },
+      operation: { kind: "mutation" }
+    }
+
+    reportGraphQLError(result, appsignal, {})
+
+    expect(span.setTags).toHaveBeenCalledWith({
+      operationType: "mutation"
+    })
+  })
+})
+
+function createMockAppsignal() {
+  const span = {
+    setTags: jest.fn(),
+    setParams: jest.fn()
+  }
+  const appsignal = {
+    sendError: jest.fn((_error: any, callback: any) => callback(span))
+  }
+  return { appsignal, span }
+}

--- a/packages/urql/src/index.ts
+++ b/packages/urql/src/index.ts
@@ -1,5 +1,9 @@
-import { pipe, tap } from 'wonka';
-import type Appsignal from '@appsignal/javascript';
+import { pipe, tap } from "wonka"
+import type Appsignal from "@appsignal/javascript"
+
+type ErrorReporter = {
+  sendError: (error: Error, callback: (span: any) => void) => void
+}
 
 /**
  * Custom urql exchange that automatically reports GraphQL errors to AppSignal.
@@ -23,46 +27,54 @@ import type Appsignal from '@appsignal/javascript';
  * });
  * ```
  */
-export const createAppsignalExchange = (appsignal: Appsignal) => ({ forward, client }: any) => (ops$: any) => {
+export const createAppsignalExchange = (appsignal: Appsignal) => ({
+  forward,
+  client
+}: any) => (ops$: any) => {
   return pipe(
     forward(ops$),
     tap((result: any) => {
       if (result.error) {
-        const { error, operation } = result;
-
-        // Convert CombinedError to a proper Error with meaningful message
-        const errorMessage = error.graphQLErrors?.length > 0
-          ? error.graphQLErrors.map((e: any) => e.message).join(', ')
-          : error.message;
-
-        const reportError = new Error(`GraphQL Error: ${errorMessage}`);
-        reportError.name = 'GraphQLError';
-        (reportError as any).stack = error.stack || reportError.stack;
-
-        // Send error to AppSignal with metadata
-        appsignal.sendError(reportError, (span) => {
-          // Add endpoint URL as a tag
-          if (client?.url) {
-            span.setTags({ endpoint: client.url });
-          }
-
-          // Add GraphQL query body as a param
-          if (operation?.query) {
-            const queryBody = operation.query.loc?.source?.body;
-            if (queryBody) {
-              span.setParams({ query: queryBody });
-            }
-          }
-
-          // Add operation metadata
-          if (operation?.operationName) {
-            span.setTags({ operationName: operation.operationName });
-          }
-          if (operation?.kind) {
-            span.setTags({ operationType: operation.kind });
-          }
-        });
+        reportGraphQLError(result, appsignal, client)
       }
     })
-  );
-};
+  )
+}
+
+export function reportGraphQLError(
+  result: any,
+  appsignal: ErrorReporter,
+  client: any
+) {
+  const { error, operation } = result
+
+  const errorMessage =
+    error.graphQLErrors?.length > 0
+      ? error.graphQLErrors.map((e: any) => e.message).join(", ")
+      : error.message
+
+  const reportError = new Error(`GraphQL Error: ${errorMessage}`)
+  reportError.name = "GraphQLError"
+  ;(reportError as any).stack = error.stack || reportError.stack
+
+  appsignal.sendError(reportError, span => {
+    if (client?.url) {
+      span.setTags({ endpoint: client.url })
+    }
+
+    if (operation?.query) {
+      const queryBody = operation.query.loc?.source?.body
+      if (queryBody) {
+        span.setParams({ query: queryBody })
+      }
+    }
+
+    if (operation?.operationName) {
+      span.setTags({ operationName: operation.operationName })
+    }
+
+    if (operation?.kind) {
+      span.setTags({ operationType: operation.kind })
+    }
+  })
+}

--- a/packages/urql/src/index.ts
+++ b/packages/urql/src/index.ts
@@ -69,10 +69,6 @@ export function reportGraphQLError(
       }
     }
 
-    if (operation?.operationName) {
-      span.setTags({ operationName: operation.operationName })
-    }
-
     if (operation?.kind) {
       span.setTags({ operationType: operation.kind })
     }

--- a/packages/urql/src/index.ts
+++ b/packages/urql/src/index.ts
@@ -1,0 +1,68 @@
+import { pipe, tap } from 'wonka';
+import type Appsignal from '@appsignal/javascript';
+
+/**
+ * Custom urql exchange that automatically reports GraphQL errors to AppSignal.
+ *
+ * This exchange intercepts all query/mutation results and reports any errors
+ * to AppSignal without requiring changes to individual useQuery calls.
+ *
+ * @example
+ * ```typescript
+ * import { createClient, fetchExchange } from 'urql';
+ * import Appsignal from '@appsignal/javascript';
+ * import { createAppsignalExchange } from '@appsignal/urql';
+ *
+ * const appsignal = new Appsignal({
+ *   key: 'YOUR FRONTEND API KEY'
+ * });
+ *
+ * const client = createClient({
+ *   url: 'https://api.example.com/graphql',
+ *   exchanges: [createAppsignalExchange(appsignal), fetchExchange]
+ * });
+ * ```
+ */
+export const createAppsignalExchange = (appsignal: Appsignal) => ({ forward, client }: any) => (ops$: any) => {
+  return pipe(
+    forward(ops$),
+    tap((result: any) => {
+      if (result.error) {
+        const { error, operation } = result;
+
+        // Convert CombinedError to a proper Error with meaningful message
+        const errorMessage = error.graphQLErrors?.length > 0
+          ? error.graphQLErrors.map((e: any) => e.message).join(', ')
+          : error.message;
+
+        const reportError = new Error(`GraphQL Error: ${errorMessage}`);
+        reportError.name = 'GraphQLError';
+        (reportError as any).stack = error.stack || reportError.stack;
+
+        // Send error to AppSignal with metadata
+        appsignal.sendError(reportError, (span) => {
+          // Add endpoint URL as a tag
+          if (client?.url) {
+            span.setTags({ endpoint: client.url });
+          }
+
+          // Add GraphQL query body as a param
+          if (operation?.query) {
+            const queryBody = operation.query.loc?.source?.body;
+            if (queryBody) {
+              span.setParams({ query: queryBody });
+            }
+          }
+
+          // Add operation metadata
+          if (operation?.operationName) {
+            span.setTags({ operationName: operation.operationName });
+          }
+          if (operation?.kind) {
+            span.setTags({ operationType: operation.kind });
+          }
+        });
+      }
+    })
+  );
+};

--- a/packages/urql/tsconfig.cjs.json
+++ b/packages/urql/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/cjs",
+    "module": "commonjs"
+  }
+}

--- a/packages/urql/tsconfig.esm.json
+++ b/packages/urql/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/esm",
+    "module": "es6"
+  }
+}

--- a/packages/urql/tsconfig.json
+++ b/packages/urql/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*"],
+  "exclude": [
+    "src/**/__tests__",
+    "src/**/__mocks__"
+  ],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "target": "es5"
+  }
+}


### PR DESCRIPTION
Based on the example implementation in https://github.com/appsignal/test-setups/tree/reproduce-graphql-error-react, this patch adds a new @appsignal/urql package that provides automatic GraphQL error reporting for applications using the urql GraphQL client.

The package exports a createAppsignalExchange function that creates a custom urql exchange to intercept all query and mutation results and automatically report errors to AppSignal without requiring changes to individual useQuery calls.

This provides a seamless integration for urql users to get complete visibility into GraphQL errors in their applications.

  ### Usage

  ```typescript
  import { createClient, fetchExchange } from 'urql';
  import Appsignal from '@appsignal/javascript';
  import { createAppsignalExchange } from '@appsignal/urql';

  const appsignal = new Appsignal({
    key: 'YOUR FRONTEND API KEY'
  });

  const client = createClient({
    url: 'https://api.example.com/graphql',
    exchanges: [createAppsignalExchange(appsignal), fetchExchange]
  });
```

### Testing

Use the https://github.com/appsignal/test-setups/tree/reproduce-graphql-error-react branch, and hook that up to a local checkout of the repository. I haven't been able to get the test-setup to fetch from GitHub directly.