### PR TITLE
Validate mono changesets in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ env:
   RUNNING_IN_CI: 'true'
   NODE_ENV: test
 jobs:
+  validate-changesets:
+    uses: "./.github/workflows/validate_changesets.yml"
   validate:
     name: Validate CI setup
     runs-on: ubuntu-latest

--- a/.github/workflows/validate_changesets.yml
+++ b/.github/workflows/validate_changesets.yml
@@ -1,0 +1,24 @@
+name: Validate changesets
+
+on:
+  workflow_call:
+
+jobs:
+  validate-changesets:
+    name: Validate changesets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+      - name: Checkout Mono
+        uses: actions/checkout@v4
+        with:
+          repository: appsignal/mono
+          path: tmp/mono
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+      - name: Validate changesets
+        run: tmp/mono/bin/mono changeset validate
+

--- a/Rakefile
+++ b/Rakefile
@@ -64,6 +64,9 @@ namespace :build_matrix do
           "NODE_ENV" => "test"
         },
         "jobs" => {
+          "validate-changesets" => {
+            "uses" => "./.github/workflows/validate_changesets.yml"
+          },
           "validate" => {
             "name" => "Validate CI setup",
             "runs-on" => "ubuntu-latest",


### PR DESCRIPTION
## Summary
- Extract the inline `validate-changesets` job into a reusable workflow (`.github/workflows/validate_changesets`)
- Reference the reusable workflow from CI and publish release workflows using `uses:`

## Context
Follows the pattern established in appsignal-wrap for reusable workflows (e.g. `build_release`). See appsignal/appsignal-kubernetes#71 review comment.